### PR TITLE
Add filter to canonicalize authors, affiliations

### DIFF
--- a/scholarly-metadata/Makefile
+++ b/scholarly-metadata/Makefile
@@ -1,0 +1,8 @@
+test: sample.md scholarly-metadata.lua
+	@pandoc --lua-filter=scholarly-metadata.lua --standalone --to=markdown $< \
+	    | diff -u - expected.md
+
+expected.md: sample.md scholarly-metadata.lua
+	pandoc --lua-filter=scholarly-metadata.lua --standalone --output $@ $<
+
+.PHONY: test

--- a/scholarly-metadata/README.md
+++ b/scholarly-metadata/README.md
@@ -1,0 +1,91 @@
+# scholarly-metadata
+
+The filter turns metadata entries for authors and their
+affiliations into a canonical form. This allows users to
+conveniently declare document authors and their affiliations,
+while making it possible to rely on default object metadata
+structures when using the data in other filters or when accessing
+the data from custom templates.
+
+
+## Canonical format for authors and affiliations
+
+Authors and affiliations entries are treated as *named objects*.
+All named objects will have an ID and a name, i.e. they are
+metadata objects with *at least* those two keys:
+
+    - id: namedObjectExample
+      name: Example for a named object.
+
+The filter converts the *author* and *institute* metadata fields
+into lists of named objects.
+
+E.g., the following YAML data
+
+    author:
+      - Jane Doe:
+          email: 'jane.doe@example.edu'
+      - John Q. Doe
+
+
+will be transformed into
+
+    author:
+    - email: 'jane.doe\@example.edu'
+      id: Jane Doe
+      name: Jane Doe
+    - id: 'John Q. Doe'
+      name: 'John Q. Doe'
+      
+Internally, `id` will be a simple string, while `name` is of type
+`MetaInlines`.
+      
+
+## Referencing affiliations
+
+Author affiliations are a common feature of scholarly
+publications. It is possible to add institutes to each author
+object. Three methods of doing this are supported.
+
+1.  **Referencing institutes by list index**: affiliations can be
+    listed in the *institute* metadata field and then referenced
+    by using the numerical index:
+    
+        institute:
+          - Acme Corporation
+          - Federation of Planets
+        author:
+          - Jane Doe:
+              institute: [1, 2]
+          - John Q. Doe:
+              institute: [2]
+        
+    This is also the canonical representation used to keep track
+    of author affiliations.
+
+2.  **Referencing institutes by ID**: using numerical indices is
+    error prone and difficult to maintain when adding or removing
+    authors or affilications. It is hence possible to use IDs
+    instead:
+
+        institute:
+          - acme: Acme Corporation
+          - federation: Federation of Planets
+        author:
+          - Jane Doe:
+              institute: [acme, federation]
+          - John Q. Doe:
+              institute: [federation]
+
+3.  **Adding institute as an attribute**: sometimes it might be
+    more convenient to give an affiliation directly in the
+    author's YAML object. Those objects can still be referenced
+    by ID from authors listed below such entry.
+    
+        author:
+          - Jane Doe:
+              institute:
+               - Acme Cooproration
+               - federation: Federation of Planets
+          - John Q. Doe:
+              institute: [federation]

--- a/scholarly-metadata/expected.md
+++ b/scholarly-metadata/expected.md
@@ -1,0 +1,41 @@
+---
+author:
+- id: Jane Doe
+  institute:
+  - 1
+  - 2
+  name: Jane Doe
+- id: 'John Q. Doe'
+  institute:
+  - 1
+  name: 'John Q. Doe'
+- id: Peder Ås
+  institute:
+  - 1
+  name: Peder Ås
+- id: Juan Pérez
+  institute:
+  - 3
+  name: Juan Pérez
+- id: Max Mustermann
+  name: Max Mustermann
+institute:
+- address: '23 Science Street, Eureka, Mississippi, USA'
+  id: fosg
+  name: Formatting Open Science Group
+- id: fop
+  name: Federation of Planets
+- id: Acme Corporation
+  name: Acme Corporation
+---
+
+Abstract
+========
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+mollit anim id est laborum.

--- a/scholarly-metadata/sample.md
+++ b/scholarly-metadata/sample.md
@@ -1,0 +1,30 @@
+---
+author:
+  - Jane Doe:
+      institute:
+        - fosg
+        - fop
+  - John Q. Doe:
+      institute: fosg
+  - Peder Ås:
+      institute: fosg
+  - Juan Pérez:
+      institute:
+        - name: Acme Corporation
+  - Max Mustermann
+institute:
+  - fosg:
+      name: Formatting Open Science Group
+      address: 23 Science Street, Eureka, Mississippi, USA
+  - fop: Federation of Planets
+...
+
+# Abstract
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+enim ad minim veniam, quis nostrud exercitation ullamco laboris
+nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+reprehenderit in voluptate velit esse cillum dolore eu fugiat
+nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/scholarly-metadata/scholarly-metadata.lua
+++ b/scholarly-metadata/scholarly-metadata.lua
@@ -1,0 +1,180 @@
+--[[
+ScholarlyMeta – normalize author/affiliation meta variables
+
+Copyright (c) 2017-2018 Albert Krewinkel, Robert Winkler
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+]]
+local List = require 'pandoc.List'
+
+-- Split a string at commas.
+local function comma_separated_values(str)
+  local acc = List:new{}
+  for substr in str:gmatch('([^,]*)') do
+    acc[#acc + 1] = substr:gsub('^%s*', ''):gsub('%s*$', '') -- trim
+  end
+  return acc
+end
+
+--- Ensure the return value is a list.
+local function ensure_list (val)
+  if type(val) ~= 'table' then
+    -- create singleton list (or empty list if val == nil).
+    return List:new{val}
+  elseif val.t == 'MetaInlines' then
+    -- check if this is really a comma-separated list
+    local csv = comma_separated_values(pandoc.utils.stringify(val))
+    if #csv >= 2 then
+      return csv
+    end
+    return List:new{val}
+  elseif val.t == 'MetaList' then
+    return List:new(val)
+  else
+    -- MetaBlocks or MetaMap, use as a singleton
+    return List:new{val}
+  end
+end
+
+--- Returns a function which checks whether an object has the given ID.
+local function has_id (id)
+  return function(x) return x.id == id end
+end
+
+--- Copy all key-value pairs of the first table into the second iff there is no
+-- such key yet in the second table.
+-- @returns the second argument
+function add_missing_entries(a, b)
+  for k, v in pairs(a) do
+    b[k] = b[k] or v
+  end
+  return b
+end
+
+--- Create an object with a name. The name is either taken directly from the
+-- `name` field, or from the *only* field name (i.e., key) if the object is a
+-- dictionary with just one entry. If neither exists, the name is left unset
+-- (`nil`).
+function to_named_object (obj)
+  local named = {}
+  if type(obj) ~= 'table' then
+    -- if the object isn't a table, just use its value as a name.
+    named.name = pandoc.MetaInlines{pandoc.Str(tostring(obj))}
+    named.id = tostring(obj)
+  elseif obj.t == 'MetaInlines' then
+      -- Treat inlines as the name
+      named.name = obj
+      named.id = pandoc.utils.stringify(obj)
+  elseif obj.name ~= nil then
+    -- object has name attribute → just create a copy of the object
+    add_missing_entries(obj, named)
+    named.id = pandoc.utils.stringify(named.id or named.name)
+  elseif next(obj) and next(obj, next(obj)) == nil then
+    -- the entry's key is taken as the name, the value contains the
+    -- attributes.
+    key, attribs = next(obj)
+    if type(attribs) == "string" or attribs.t == 'MetaInlines' then
+      named.name = attribs
+    else
+      add_missing_entries(attribs, named)
+      named.name = named.name or pandoc.MetaInlines{pandoc.Str(tostring(key))}
+    end
+    named.id = named.id and pandoc.utils.stringify(named.id) or key
+  else
+    -- this is not a named object adhering to the usual conventions.
+    error('not a named object: ' .. tostring(obj))
+  end
+  return named
+end
+
+--- Resolve institute placeholders to full named objects
+local function resolve_institutes (institute, known_institutes)
+  local unresolved_institutes
+  if institute == nil then
+    unresolved_institutes = {}
+  elseif type(institute) == "string" or type(institute) == "number" then
+    unresolved_institutes = {institute}
+  else
+    unresolved_institutes = institute
+  end
+
+  local result = List:new{}
+  for i, inst in ipairs(unresolved_institutes) do
+    result[i] =
+      known_institutes[tonumber(inst)] or
+      known_institutes:find_if(has_id(pandoc.utils.stringify(inst))) or
+      to_named_object(inst)
+  end
+  return result
+end
+
+--- Insert a named object into a list; if an object of the same name exists
+-- already, add all properties only present in the new object to the existing
+-- item.
+function merge_on_id (list, namedObj)
+  local elem, idx = list:find_if(has_id(namedObj.id))
+  local res = elem and add_missing_entries(namedObj, elem) or namedObj
+  local obj_idx = idx or (#list + 1)
+  -- return res, obj_idx
+  list[obj_idx] = res
+  return res, #list
+end
+
+--- Flatten a list of lists.
+local function flatten (lists)
+  local result = List:new{}
+  for _, lst in ipairs(lists) do
+    result:extend(lst)
+  end
+  return result
+end
+
+--- Canonicalize authors and institutes
+local function canonicalize(raw_author, raw_institute)
+  local institutes = ensure_list(raw_institute):map(to_named_object)
+  local authors = ensure_list(raw_author):map(to_named_object)
+
+  for _, author in ipairs(authors) do
+    author.institute = resolve_institutes(
+      ensure_list(author.institute),
+      institutes
+    )
+  end
+
+  -- Merge institutes defined in author objects with those defined in the
+  -- top-level list.
+  local author_insts = flatten(authors:map(function(x) return x.institute end))
+  for _, inst in ipairs(author_insts) do
+    merge_on_id(institutes, inst)
+  end
+
+  -- replace institutes with their indices
+  local to_index = function (inst)
+    return tostring(select(2, institutes:find_if(has_id(inst.id))))
+  end
+  for _, author in ipairs(authors) do
+    author.institute = pandoc.MetaList(author.institute:map(to_index))
+  end
+
+  return authors, institutes
+end
+
+
+return {
+  {
+    Meta = function(meta)
+      meta.author, meta.institute = canonicalize(meta.author, meta.institute)
+      return meta
+    end
+  }
+}


### PR DESCRIPTION
The filter turns metadata entries for authors and their affiliations
into a canonical form. This allows users to conveniently declare
document authors and their affiliations, while making it possible to
rely on default object metadata structures when using the data in other
filters or when accessing the data from custom templates.