### PR TITLE
Add filter to move abstract from body to metadata

### DIFF
--- a/abstract-to-meta/Makefile
+++ b/abstract-to-meta/Makefile
@@ -1,0 +1,8 @@
+test: sample.md abstract-to-meta.lua
+	@pandoc --lua-filter=abstract-to-meta.lua --standalone --to=markdown $< \
+	    | diff -u - expected.md
+
+expected.md: sample.md abstract-to-meta.lua
+	pandoc --lua-filter=abstract-to-meta.lua --standalone --output $@ $<
+
+.PHONY: test

--- a/abstract-to-meta/README.md
+++ b/abstract-to-meta/README.md
@@ -1,0 +1,37 @@
+# abstract-to-meta
+
+This moves a document's abstract from the main text into the
+metadata. Metadata elements usually allow for finer placement
+control in the final output, but writing body text is easier and
+more natural.
+
+## Defining an Abstract
+
+A document abstract can either be put directly in the document
+metadata, for example by inserting an *abstract* attribute into a
+YAML block.
+
+    ---
+    abstract: |
+      Place abstract here.
+
+      Multiple paragraphs are possible.
+    ---
+
+The additional indentation and formatting requirements in YAML
+headers can be confusing or annoying for authors. It is hence
+preferable to allow abstracts be written as normal sections.
+
+    # Abstract
+
+    Place abstract here.
+
+    Multiple paragraphs are possible.
+
+This filter turns the latter into the former by looking for a
+top-level header whose ID is `abstract`. Pandoc auto-creates IDs
+based on header contents, so a header titled *Abstract* will
+satisfy this condition.^[1]
+
+[1]: This requires the `auto_identifier` extension. It is
+     enabled by default.

--- a/abstract-to-meta/abstract-to-meta.lua
+++ b/abstract-to-meta/abstract-to-meta.lua
@@ -1,0 +1,23 @@
+local looking_at_abstract = false
+local abstract = {}
+
+function Block (elem)
+  if looking_at_abstract then
+    abstract[#abstract + 1] = elem
+    return {}
+  end
+end
+
+function Header (elem)
+  if elem.level == 1 and elem.identifier == 'abstract' then
+    looking_at_abstract = true
+    return {}
+  else
+    looking_at_abstract = looking_at_abstract and elem.level ~= 1
+  end
+end
+
+function Meta (meta)
+  meta.abstract = meta.abstract or pandoc.MetaBlocks(abstract)
+  return meta
+end

--- a/abstract-to-meta/expected.md
+++ b/abstract-to-meta/expected.md
@@ -1,0 +1,19 @@
+---
+abstract: |
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+    velit esse cillum dolore eu fugiat nulla pariatur.
+
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+    officia deserunt mollit anim id est laborum.
+---
+
+Lorem Ipsum
+===========
+
+Quo dolore molestiae et laboriosam occaecati explicabo corrupti. Earum
+expedita ducimus quaerat est quam ut molestiae. Illum deleniti vel
+labore facilis et cum est. Est nemo est vel ad. Assumenda consequatur
+rerum officiis atque officia. Est nihil iste cumque ad qui.

--- a/abstract-to-meta/sample.md
+++ b/abstract-to-meta/sample.md
@@ -1,0 +1,17 @@
+# Abstract
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur.
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum.
+
+# Lorem Ipsum
+
+Quo dolore molestiae et laboriosam occaecati explicabo corrupti. Earum expedita
+ducimus quaerat est quam ut molestiae. Illum deleniti vel labore facilis et cum
+est. Est nemo est vel ad. Assumenda consequatur rerum officiis atque officia.
+Est nihil iste cumque ad qui.


### PR DESCRIPTION
This moves a document's abstract from the main text into the
metadata. Metadata elements usually allow for finer placement
control in the final output, but writing body text is easier and
more natural.