### PR TITLE
other-language: 

### DIFF
--- a/other-language/Makefile
+++ b/other-language/Makefile
@@ -1,0 +1,6 @@
+test:
+	@pandoc --lua-filter=other-language.lua --output=output.tex sample.md
+	@diff -u expected.tex output.tex
+	@rm -f output.tex
+
+.PHONY: test

--- a/other-language/README.md
+++ b/other-language/README.md
@@ -1,0 +1,37 @@
+# other-language for TeX code blocks
+
+This filter ensures that the raw content such a code blocks are enclosed with
+the english language so any typographic rules existing the base language are
+not applied. It was conceived with French in mind but surely can be useful to
+other languages.
+
+## Using the filter
+
+For it to do anything, the main document language should be something else than
+`en`, e.g. `fr`.
+
+```yaml
+---
+lang: fr
+---
+```
+
+Which will produce
+
+```latex
+\documentclass[french,]{article}
+
+% ...
+
+\usepackage[shorthands=off,english,main=french]{babel}
+
+% ...
+
+\usepackage{polyglossia}
+\setmainlanguage[]{french}
+\setotherlanguage[]{english}
+```
+
+Then any code block, or inline code will be surrounded with the
+`\begin{otherlanguage}{english}` and `\end{otherlanguage}`. It will be killing
+off any typographic changes such as the insecable space before a colon.

--- a/other-language/expected.tex
+++ b/other-language/expected.tex
@@ -1,0 +1,20 @@
+\begin{otherlanguage}{english}
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\FunctionTok{lang:}\AttributeTok{ fr}
+\end{Highlighting}
+\end{Shaded}
+
+\end{otherlanguage}
+
+\begin{otherlanguage}{english}
+
+\begin{verbatim}
+lang: fr
+\end{verbatim}
+
+\end{otherlanguage}
+
+In a paragraph,
+\begin{otherlanguage}{english}\texttt{lang:\ fr}\end{otherlanguage}.

--- a/other-language/other-language.lua
+++ b/other-language/other-language.lua
@@ -1,0 +1,43 @@
+local lang = 'english'
+
+local before = pandoc.RawInline(
+  'tex', '\\begin{otherlanguage}{' .. lang .. '}')
+local after = pandoc.RawInline(
+  'tex', '\\end{otherlanguage}')
+
+local meta = {}
+
+return {
+  {
+    Meta = function (el)
+      meta = el
+      meta['babel-otherlangs'] = lang
+      meta['polyglossia-otherlangs'] = {name = lang}
+      return {}
+    end,
+  }, {
+    Code = function(code)
+      return {before, code, after}
+    end,
+
+    CodeBlock = function(code_block)
+      return {
+        pandoc.Para({before}),
+        code_block,
+        pandoc.Para({after})
+      }
+    end,
+
+    RawBlock = function(raw_block)
+      return {
+        pandoc.Para({before}),
+        raw_block,
+        pandoc.Para({after})
+      }
+    end,
+  }, {
+    Meta = function (_)
+      return meta
+    end,
+  }
+}

--- a/other-language/sample.md
+++ b/other-language/sample.md
@@ -1,0 +1,13 @@
+---
+lang: fr
+---
+
+```yaml
+lang: fr
+```
+
+```
+lang: fr
+```
+
+In a paragraph, `lang: fr`.


### PR DESCRIPTION
A filter I've been using to avoid french hyphenation in code blocks once transformed into a TeX document.

**source**

```markdown
```yaml
title: Mon titre
lang: fr
```

**without**

![screenshot from 2018-12-30 15-05-10](https://user-images.githubusercontent.com/1388/50547933-52532180-0c44-11e9-97db-2d58b7c541d1.png)

**with**

![screenshot from 2018-12-30 15-03-59](https://user-images.githubusercontent.com/1388/50547934-52532180-0c44-11e9-8a25-e22c9b02e181.png)


Extracted from this project: https://github.com/HE-Arc/rapport-technique