### PR TITLE
minted: Fix inline code when it contains special characters.

### DIFF
--- a/minted/minted.lua
+++ b/minted/minted.lua
@@ -346,7 +346,7 @@ function Code(elem)
 
     -- Check for local or global bypass to turn off \mintinline
     if minted_no_mintinline or found_no_minted_class then
-      return pandoc.RawInline("latex", string.format("\\texttt{%s}", elem.text))
+      return elem
     end
 
     local start_delim, end_delim

--- a/minted/run_minted_tests.py
+++ b/minted/run_minted_tests.py
@@ -31,7 +31,8 @@ inline_code = textwrap.dedent('''
     `#include <type_traits>`{.cpp}
     C and C++ use `{` and `}` to delimit scopes.
     Some other special characters:
-    ''' + ' '.join(
+    These check bypass: `~!@#$%^&*()-=_+[]\\{}|;\':",./<>?`
+    These check regular inline: ''' + ' '.join(
     '`{' + inline_delims[:i] + '`' for i in range(len(inline_delims))
 ))
 """
@@ -328,14 +329,17 @@ def run_tex_tests(args, fmt):
             ---
             {inline_code}
         ''').format(inline_code=inline_code),
-        r"\texttt{#include <type_traits>}",
-        r"\texttt{{}",
-        r"\texttt{}}"
+        r"\VERB|\PreprocessorTok{#include }\ImportTok{<type_traits>}|",
+        r"\texttt{\{}",
+        r"\texttt{\}}",
+        (r"\texttt{"
+         r"\textasciitilde{}!@\#\$\%\^{}\&*()-=\_+{[}{]}\textbackslash{}\{\}"
+         r"""\textbar{};\textquotesingle{}:",./\textless{}\textgreater{}?}"""),
     )
     verify(
         "[inline-code] .no_minted class bypasses single inline code element",
         inline_code.replace("{.cpp}", "{.cpp .no_minted}"),
-        r"\texttt{#include <type_traits>}",
+        r"\VERB|\PreprocessorTok{#include }\ImportTok{<type_traits>}|",
         "|{|",
         "|}|"
     )

--- a/minted/sample.md
+++ b/minted/sample.md
@@ -30,30 +30,28 @@ minted:
 - Raw inline code:
 
     ```md
-    `#include <type_traits>` `if (i == 0) {`
+    `#include <type_traits>`
     ```
 
-  \vspace*{-3ex} produces: `#include <type_traits>` `if (i == 0) {`
+  \vspace*{-3ex} produces: `#include <type_traits>`
 
 - Apply just a lexer:
 
     ```md
-    `#include <type_traits>`{.cpp} `if (i == 0) {`{.cpp}
+    `#include <type_traits>`{.cpp}
     ```
 
-    \vspace*{-3ex} produces: `#include <type_traits>`{.cpp} `if (i == 0) {`{.cpp}
+    \vspace*{-3ex} produces: `#include <type_traits>`{.cpp}
 
 - Change the background color and highlighting style:
 
     ```{.md fontsize=\scriptsize}
     <!-- Note: we defined monokai_bg in the metadata! -->
     `#include <type_traits>`{.cpp bgcolor=monokai_bg style=monokai}
-    `if (i == 0) {`{.cpp bgcolor=monokai_bg style=monokai}
     ```
 
     \vspace*{-3ex} produces:
     `#include <type_traits>`{.cpp bgcolor=monokai_bg style=monokai}
-    `if (i == 0) {`{.cpp bgcolor=monokai_bg style=monokai}
 
     - Must **always** include language (`.cpp` here) **first**, always!
 
@@ -108,3 +106,26 @@ minted:
     \vspace*{-3ex}
 
     - Must **always** include language (`.bash` here) **first**, always!
+
+
+## Special Characters
+
+Special characters should be supported in all cases:
+
+- Code blocks:
+
+    ```md
+    `~!@#$%^&*()-=_+[]}{|;':",.\/<>?
+    ```
+
+- Inline code
+
+    ``with mintinline `~!@#$%^&*()-=_+[]}{|;':",.\/<>?``
+
+  Note: If you use almost all special characters *and* all alphanumeric
+  characters in a single inline code fragment, minted may not be able to find a
+  suitable delimiter to place around the \LaTeX\ inline command.
+
+- Inline code with bypass
+
+    ``no mintinline `~!@#$%^&*()-=_+[]}{|;':",.\/<>?``{.text .no_minted}

--- a/minted/sample.md
+++ b/minted/sample.md
@@ -30,28 +30,30 @@ minted:
 - Raw inline code:
 
     ```md
-    `#include <type_traits>`
+    `#include <type_traits>` `if (i == 0) {`
     ```
 
-  \vspace*{-3ex} produces: `#include <type_traits>`
+  \vspace*{-3ex} produces: `#include <type_traits>` `if (i == 0) {`
 
 - Apply just a lexer:
 
     ```md
-    `#include <type_traits>`{.cpp}
+    `#include <type_traits>`{.cpp} `if (i == 0) {`{.cpp}
     ```
 
-    \vspace*{-3ex} produces: `#include <type_traits>`{.cpp}
+    \vspace*{-3ex} produces: `#include <type_traits>`{.cpp} `if (i == 0) {`{.cpp}
 
 - Change the background color and highlighting style:
 
     ```{.md fontsize=\scriptsize}
-    <!-- Note: we defined monkai_bg in the metadata! -->
+    <!-- Note: we defined monokai_bg in the metadata! -->
     `#include <type_traits>`{.cpp bgcolor=monokai_bg style=monokai}
+    `if (i == 0) {`{.cpp bgcolor=monokai_bg style=monokai}
     ```
 
     \vspace*{-3ex} produces:
     `#include <type_traits>`{.cpp bgcolor=monokai_bg style=monokai}
+    `if (i == 0) {`{.cpp bgcolor=monokai_bg style=monokai}
 
     - Must **always** include language (`.cpp` here) **first**, always!
 


### PR DESCRIPTION
If an inline code section contains an unmatched brace, then using braces as the `\mintinline` delimiter breaks. The inline section will extend to the next matching brace instead.

`\mintinline` can use any other character for a delimiter, so try to switch to something else when braces are in the text.

Fixes #42.