### PR TITLE
document/test impact of `--no-highlight` on minted filter

### DIFF
--- a/minted/Makefile
+++ b/minted/Makefile
@@ -23,14 +23,14 @@ pandoc_inputs := sample.md
 
 # Sample beamer presentation.
 sample_beamer.tex: $(pandoc_inputs)
-	pandoc -s -t beamer --lua-filter=minted.lua $^ > $@
+	pandoc -s -t beamer --no-highlight --lua-filter=minted.lua $^ > $@
 
 sample_beamer.pdf: sample_beamer.tex
 	latexmk -pdf -shell-escape -jobname=sample_beamer sample_beamer
 
 # Sample latex document.
 sample_latex.tex: $(pandoc_inputs)
-	pandoc -s -t latex --lua-filter=minted.lua $^ > $@
+	pandoc -s -t latex --no-highlight --lua-filter=minted.lua $^ > $@
 
 sample_latex.pdf: sample_latex.tex
 	latexmk -pdf -shell-escape -jobname=sample_latex sample_latex

--- a/minted/README.md
+++ b/minted/README.md
@@ -266,6 +266,31 @@ There are two rules that must not be violated:
    If you violate this, then `pandoc` will likely not produce an actual inline
    `Code` or `CodeBlock` element, but instead something else (undefined).
 
+Last, but not least, you will see that the `--no-highlight` flag is used in the
+`Makefile` for the latex targets.  This is added in the spirit of the filter
+being a "full replacement" for `pandoc` highlighting with `minted`.  This only
+affects inline code elements that meet the following criteria:
+
+1. The inline code element has a lexer, e.g., `{.cpp}`.
+2. The inline code element can actually be parsed for that language by `pandoc`.
+
+If these two conditions are met, and you do **not** specify `--no-highlight`,
+the `pandoc` highlighting engine will take over.  Users are encouraged to build
+the samples (`make` in this directory) and look at the end of the
+`Special Characters are Supported` section.  If you remove `--no-highlight`,
+`make realclean`, and then `make` again, you will see that the pandoc
+highlighting engine will colorize the `auto foo = [](){};`.
+
+Simply put: if you do not want any pandoc highlighting in your LaTeX, **make
+sure you add `--no-highlight`** and it will not happen.
+
+It is advantageous for this filter to rely on this behavior, because it means
+that the filter does not need to worry about escaping special characters for
+LaTeX -- `pandoc` will do that for us.  Inspect the generated `sample_*.tex`
+files (near the end) to see the difference.  `--no-highlight` will produce
+`\texttt` commands, but omitting this flag will result in some `\VERB` commands
+from `pandoc`.
+
 # Bonus
 
 Included here is a simple python script to help you get the right color

--- a/minted/minted.lua
+++ b/minted/minted.lua
@@ -378,7 +378,7 @@ function Code(elem)
 
     -- Check for local or global bypass to turn off \mintinline
     if minted_no_mintinline or found_no_minted_class then
-      return elem
+      return nil -- Return `nil` signals to `pandoc` that elem is not changed.
     end
 
     local start_delim, end_delim = minted_inline_delims(elem.text)

--- a/minted/sample.md
+++ b/minted/sample.md
@@ -108,15 +108,15 @@ minted:
     - Must **always** include language (`.bash` here) **first**, always!
 
 
-## Special Characters
-
-Special characters should be supported in all cases:
+## Special Characters are Supported
 
 - Code blocks:
 
     ```md
     `~!@#$%^&*()-=_+[]}{|;':",.\/<>?
     ```
+
+    \vspace*{-3ex}
 
 - Inline code
 
@@ -129,3 +129,7 @@ Special characters should be supported in all cases:
 - Inline code with bypass
 
     ``no mintinline `~!@#$%^&*()-=_+[]}{|;':",.\/<>?``{.text .no_minted}
+
+- Specific lexer with mintinline: `auto foo = [](){};`{.cpp}
+- Without mintinline: `auto foo = [](){};`{.cpp .no_minted}
+    - Output color depends on `--no-highlight` flag for `pandoc`.


### PR DESCRIPTION
- [x] Add `--no-highlight` to `Makefile`
- [x] Document in README impact of `--no-highlight` flag and how this filter behaves.
- [x] Add explicit test in the sample to show how `--no-highlight` affects output.  (Deletions in that section are just to make it all fit in a single beamer slide).
- [x] Restructure latex tests to require pandoc arguments passed in as second parameter to `verify` local function.  Makes it so that default tests use `--no-highlight`, but two tests remove this and verify that the `pandoc` highlighting commands get used.

Only filter change is to `return nil` instead of `return elem` because @tarleb said that was slightly faster for `pandoc`.  Everything else is just documentation and testing impact of `--no-highlight` flag.