### PR TITLE
Short-captions for Tables

### DIFF
--- a/table-short-captions/Makefile
+++ b/table-short-captions/Makefile
@@ -1,0 +1,15 @@
+LF	=	--lua-filter=table-short-captions.lua
+F	=	-F pandoc-crossref
+
+readme:
+	@pandoc -s $(LF) $(F)  README.md -o README.pdf
+
+sample:
+	@pandoc -s $(LF) $(F) -t latex sample.md -o sample.tex
+	@pandoc -s $(LF) $(F) -t latex sample.md -o sample.pdf
+
+test: sample
+	diff --strip-trailing-cr expected-sample.tex sample.tex
+
+clean:
+	rm -v *.aux *.dvi *.fdb_latexmk *.fls *.log *.lot *.ps *.pdf sample.tex | true

--- a/table-short-captions/README.md
+++ b/table-short-captions/README.md
@@ -23,7 +23,13 @@ The [pandoc-crossref](http://lierdakil.github.io/pandoc-crossref/) filter extend
 
 This filter, when run _before_ pandoc-crossref, allows you to add short captions to the table as a `short-caption` attribute. What is between the quotes will be parsed as Markdown.
 
-    Table: This is the *italicised long caption* of my table, which has a very long caption. {#tbl:full-of-juicy-data short-caption="Short caption for *juicy* data table."}
+**Important!:** You _must_ use empty square brackets before the attributes tag.
+
+    Table: This is the *italicised long caption* of my table, which has a very long caption. []{#tbl:full-of-juicy-data short-caption="Short caption for *juicy* data table."}
+
+Alternatively, if you wish to create a table which is unlisted in the List of Tables, you can use the `.unlisted` class in the attributes tag.
+
+    Table: This is the *italicised long caption* of my table, which will not appear in the List of Tables. []{#tbl:full-of-juicy-data .unlisted}
 
 This filter should prove useful for students writing dissertations, who often have to include a List of Tables in the front matter, but where table captions themselves can be quite lengthy.
 

--- a/table-short-captions/README.md
+++ b/table-short-captions/README.md
@@ -1,0 +1,39 @@
+---
+title: "table-short-captions.lua"
+lot: true
+---
+
+# Short captions in \LaTeX\ tables output
+
+For LaTeX output, this filter enables use of the attribute `short-caption` for tables. The attribute value will appear in the List of Tables.
+
+This filter also enables the class `.unlisted` for tables. This will prevent the table caption from appearing in the List of Tables.
+
+# Usage
+
+In Pandoc Markdown, you can add a caption to a table with
+
+    Table: This is the *italicised long caption* of my table, which has a very long caption.
+
+If the document metadata includes `lot:true`, then the List of Tables will be inserted at the beginning of the document.
+
+The [pandoc-crossref](http://lierdakil.github.io/pandoc-crossref/) filter extends this, and enables you to specify a custom label for the table.
+
+    Table: This is the *italicised long caption* of my table, which has a very long caption.  {#tbl:full-of-juicy-data}
+
+This filter, when run _before_ pandoc-crossref, allows you to add short captions to the table as a `short-caption` attribute. What is between the quotes will be parsed as Markdown.
+
+    Table: This is the *italicised long caption* of my table, which has a very long caption. {#tbl:full-of-juicy-data short-caption="Short caption for *juicy* data table."}
+
+This filter should prove useful for students writing dissertations, who often have to include a List of Tables in the front matter, but where table captions themselves can be quite lengthy.
+
+    pandoc --lua-filter=table-short-captions.lua --filter pandoc-crossref article.md -o article.tex
+
+    pandoc --lua-filter=table-short-captions.lua --filter pandoc-crossref article.md -o article.pdf
+
+
+# Limitations
+
+- The filter will process the `short-caption` attribute value as pandoc markdown, regardless of the input format.
+- pandoc-crossref should be run after it.
+- I have only tested this from a Markdown source.

--- a/table-short-captions/expected-sample.tex
+++ b/table-short-captions/expected-sample.tex
@@ -1,0 +1,266 @@
+\PassOptionsToPackage{unicode=true}{hyperref} % options for packages loaded elsewhere
+\PassOptionsToPackage{hyphens}{url}
+%
+\documentclass[
+]{article}
+\usepackage{lmodern}
+\usepackage{amssymb,amsmath}
+\usepackage{ifxetex,ifluatex}
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \usepackage[T1]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provides euro and other symbols
+\else % if luatex or xelatex
+  \usepackage{unicode-math}
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+\fi
+% use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+\usepackage{xcolor}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
+\hypersetup{
+  pdftitle={Tests for table-short-captions.lua},
+  pdfborder={0 0 0},
+  breaklinks=true}
+\urlstyle{same}  % don't use monospace font for urls
+\usepackage{longtable,booktabs}
+% Allow footnotes in longtable head/foot
+\IfFileExists{footnotehyper.sty}{\usepackage{footnotehyper}}{\usepackage{footnote}}
+\makesavenoteenv{longtable}
+\setlength{\emergencystretch}{3em}  % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+\setcounter{secnumdepth}{-2}
+% Redefines (sub)paragraphs to behave more like sections
+\ifx\paragraph\undefined\else
+  \let\oldparagraph\paragraph
+  \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
+\fi
+\ifx\subparagraph\undefined\else
+  \let\oldsubparagraph\subparagraph
+  \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
+\fi
+
+% set default figure placement to htbp
+\makeatletter
+\def\fps@figure{htbp}
+\makeatother
+
+% -- begin:latex-table-short-captions --
+\makeatletter\AtBeginDocument{%
+\def\LT@c@ption#1[#2]#3{%                 % Overwrite the workhorse macro used in formatting a longtable caption.
+  \LT@makecaption#1\fnum@table{#3}%
+  \ifdefined\pandoctableshortcapt         % If pandoctableshortcapt is defined (even if blank), we should override default behaviour.
+     \let\@tempa\pandoctableshortcapt%    % (Use let, we don't want to expand pandoctableshortcapt!)
+  \else                                   % If not, fall back to default behaviour
+     \def\@tempa{#2}%                     % (Use the argument in square brackets)
+  \fi
+  \ifx\@tempa\@empty\else                 % If @tempa is blank, no lot entry! Otherwise, @tempa becomes the lot title.
+     {\let\\\space
+     \addcontentsline{lot}{table}{\protect\numberline{\thetable}{\@tempa}}}%
+  \fi}
+}\makeatother
+% -- end:latex-table-short-captions --
+\makeatletter
+\@ifpackageloaded{subfig}{}{\usepackage{subfig}}
+\@ifpackageloaded{caption}{}{\usepackage{caption}}
+\captionsetup[subfloat]{margin=0.5em}
+\AtBeginDocument{%
+\renewcommand*\figurename{Figure}
+\renewcommand*\tablename{Table}
+}
+\AtBeginDocument{%
+\renewcommand*\listfigurename{List of Figures}
+\renewcommand*\listtablename{List of Tables}
+}
+\@ifpackageloaded{float}{}{\usepackage{float}}
+\floatstyle{ruled}
+\@ifundefined{c@chapter}{\newfloat{codelisting}{h}{lop}}{\newfloat{codelisting}{h}{lop}[chapter]}
+\floatname{codelisting}{Listing}
+\newcommand*\listoflistings{\listof{codelisting}{List of Listings}}
+\makeatother
+
+\title{Tests for table-short-captions.lua}
+\date{}
+
+\begin{document}
+\maketitle
+
+\listoftables
+These tests are written so that if \textbf{bold font} appears in the
+LOT, something is wrong.
+
+\begin{longtable}[]{@{}ll@{}}
+\caption{This is the \emph{italicised long caption} of tbl1, which does
+not have a label.}\tabularnewline
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endfirsthead
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endhead
+a1 & b1\tabularnewline
+a2 & b2\tabularnewline
+\bottomrule
+\end{longtable}
+
+\begin{longtable}[]{@{}ll@{}}
+\caption{This is the \emph{italicised long caption} of tbl2, which does
+not have a label, but does have empty braces at the end.}\tabularnewline
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endfirsthead
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endhead
+a1 & b1\tabularnewline
+a2 & b2\tabularnewline
+\bottomrule
+\end{longtable}
+
+\begin{longtable}[]{@{}ll@{}}
+\caption{This is the \emph{italicised long caption} of
+tbl3.}\tabularnewline
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endfirsthead
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endhead
+a1 & b1\tabularnewline
+a2 & b2\tabularnewline
+\bottomrule
+\end{longtable}
+
+\def\pandoctableshortcapt{}  % .unlisted
+
+\hypertarget{tbl:tbl-label4}{}
+\begin{longtable}[]{@{}ll@{}}
+\caption{\label{tbl:tbl-label4}This is the \emph{italicised long
+caption} of tbl4, which is \textbf{unlisted}. This is expected
+usage.}\tabularnewline
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endfirsthead
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endhead
+a1 & b1\tabularnewline
+a2 & b2\tabularnewline
+\bottomrule
+\end{longtable}
+
+\undef\pandoctableshortcapt
+
+\def\pandoctableshortcapt{Table 5 \emph{short} capt.}
+
+\hypertarget{tbl:tbl-label5}{}
+\begin{longtable}[]{@{}ll@{}}
+\caption{\label{tbl:tbl-label5}This is the \emph{italicised long
+caption} of tbl5, which has an \textbf{overriding} short-caption. This
+is the expected usage.}\tabularnewline
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endfirsthead
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endhead
+a1 & b1\tabularnewline
+a2 & b2\tabularnewline
+\bottomrule
+\end{longtable}
+
+\undef\pandoctableshortcapt
+
+\def\pandoctableshortcapt{}  % .unlisted
+
+\hypertarget{tbl:tbl-label6}{}
+\begin{longtable}[]{@{}ll@{}}
+\caption{\label{tbl:tbl-label6}This is the \emph{italicised long
+caption} of tbl6, which is \textbf{unlisted}, yet has a
+short-caption.}\tabularnewline
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endfirsthead
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endhead
+a1 & b1\tabularnewline
+a2 & b2\tabularnewline
+\bottomrule
+\end{longtable}
+
+\undef\pandoctableshortcapt
+
+\def\pandoctableshortcapt{}  % .unlisted
+
+\hypertarget{tbl:tbl-label7}{}
+\begin{longtable}[]{@{}ll@{}}
+\caption{\label{tbl:tbl-label7}This is the \emph{italicised long
+caption} of tbl7, which is \textbf{unlisted}, yet has a short-caption
+and other bogus classes}\tabularnewline
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endfirsthead
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endhead
+a1 & b1\tabularnewline
+a2 & b2\tabularnewline
+\bottomrule
+\end{longtable}
+
+\undef\pandoctableshortcapt
+
+\hypertarget{tbl:tbl-label8}{}
+\begin{longtable}[]{@{}ll@{}}
+\caption{\label{tbl:tbl-label8}This is the \emph{italicised long
+caption} of tbl8, which has an empty short-caption. An empty
+short-caption does nothing. The long caption will still be
+used.}\tabularnewline
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endfirsthead
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endhead
+a1 & b1\tabularnewline
+a2 & b2\tabularnewline
+\bottomrule
+\end{longtable}
+
+This is the last paragraph, just to tie things up.
+
+\end{document}

--- a/table-short-captions/expected-sample.tex
+++ b/table-short-captions/expected-sample.tex
@@ -106,6 +106,14 @@
 These tests are written so that if \textbf{bold font} appears in the
 LOT, something is wrong.
 
+The tests are split into two: expected uses, and non-standard
+uses/errors.\\
+The non-standard uses are presented in this document for troubleshooting
+purposes, and to ensure the filter doesn't crash in corner cases.
+
+\hypertarget{standard-usage}{%
+\section{Standard usage}\label{standard-usage}}
+
 \begin{longtable}[]{@{}ll@{}}
 \caption{This is the \emph{italicised long caption} of tbl1, which does
 not have a label.}\tabularnewline
@@ -122,25 +130,11 @@ a2 & b2\tabularnewline
 \bottomrule
 \end{longtable}
 
+\hypertarget{tbl:tbl-label2}{}
 \begin{longtable}[]{@{}ll@{}}
-\caption{This is the \emph{italicised long caption} of tbl2, which does
-not have a label, but does have empty braces at the end.}\tabularnewline
-\toprule
-cola & colb\tabularnewline
-\midrule
-\endfirsthead
-\toprule
-cola & colb\tabularnewline
-\midrule
-\endhead
-a1 & b1\tabularnewline
-a2 & b2\tabularnewline
-\bottomrule
-\end{longtable}
-
-\begin{longtable}[]{@{}ll@{}}
-\caption{This is the \emph{italicised long caption} of
-tbl3.}\tabularnewline
+\caption{\label{tbl:tbl-label2}This is the \emph{italicised long
+caption} of tbl2, in standard \texttt{pandoc-crossref}
+form.}\tabularnewline
 \toprule
 cola & colb\tabularnewline
 \midrule
@@ -156,11 +150,10 @@ a2 & b2\tabularnewline
 
 \def\pandoctableshortcapt{}  % .unlisted
 
-\hypertarget{tbl:tbl-label4}{}
+\hypertarget{tbl:tbl-label3}{}
 \begin{longtable}[]{@{}ll@{}}
-\caption{\label{tbl:tbl-label4}This is the \emph{italicised long
-caption} of tbl4, which is \textbf{unlisted}. This is expected
-usage.}\tabularnewline
+\caption{\label{tbl:tbl-label3}This is the \emph{italicised long
+caption} of tbl3, which is \textbf{unlisted}.}\tabularnewline
 \toprule
 cola & colb\tabularnewline
 \midrule
@@ -176,12 +169,12 @@ a2 & b2\tabularnewline
 
 \undef\pandoctableshortcapt
 
-\def\pandoctableshortcapt{Table 5 \emph{short} capt.}
+\def\pandoctableshortcapt{Table 4 \emph{short} capt.}
 
-\hypertarget{tbl:tbl-label5}{}
+\hypertarget{tbl:tbl-label4}{}
 \begin{longtable}[]{@{}ll@{}}
-\caption{\label{tbl:tbl-label5}This is the \emph{italicised long
-caption} of tbl5, which has an \textbf{overriding} short-caption. This
+\caption{\label{tbl:tbl-label4}This is the \emph{italicised long
+caption} of tbl4, which has an \textbf{overriding} short-caption. This
 is the expected usage.}\tabularnewline
 \toprule
 cola & colb\tabularnewline
@@ -198,13 +191,13 @@ a2 & b2\tabularnewline
 
 \undef\pandoctableshortcapt
 
-\def\pandoctableshortcapt{}  % .unlisted
+\hypertarget{non-standard-usageerrors}{%
+\section{Non-standard usage/errors}\label{non-standard-usageerrors}}
 
-\hypertarget{tbl:tbl-label6}{}
 \begin{longtable}[]{@{}ll@{}}
-\caption{\label{tbl:tbl-label6}This is the \emph{italicised long
-caption} of tbl6, which is \textbf{unlisted}, yet has a
-short-caption.}\tabularnewline
+\caption{This is the \emph{italicised long caption} of tbl5, which does
+not have a label, but does have empty braces at the end.
+\{\}}\tabularnewline
 \toprule
 cola & colb\tabularnewline
 \midrule
@@ -218,15 +211,10 @@ a2 & b2\tabularnewline
 \bottomrule
 \end{longtable}
 
-\undef\pandoctableshortcapt
-
-\def\pandoctableshortcapt{}  % .unlisted
-
-\hypertarget{tbl:tbl-label7}{}
 \begin{longtable}[]{@{}ll@{}}
-\caption{\label{tbl:tbl-label7}This is the \emph{italicised long
-caption} of tbl7, which is \textbf{unlisted}, yet has a short-caption
-and other bogus classes}\tabularnewline
+\caption{This is the \emph{italicised long caption} of tbl6, which does
+not have a label, but does have an empty span at the end.
+}\tabularnewline
 \toprule
 cola & colb\tabularnewline
 \midrule
@@ -240,7 +228,23 @@ a2 & b2\tabularnewline
 \bottomrule
 \end{longtable}
 
-\undef\pandoctableshortcapt
+\begin{longtable}[]{@{}ll@{}}
+\caption{This is the \emph{italicised long caption} of tbl7, which is
+improperly formatted, and will appear in the list of tables. This filter
+requires that \texttt{.unlisted} is placed in a span. \{\#tbl:tbl-label7
+.unlisted\}}\tabularnewline
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endfirsthead
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endhead
+a1 & b1\tabularnewline
+a2 & b2\tabularnewline
+\bottomrule
+\end{longtable}
 
 \hypertarget{tbl:tbl-label8}{}
 \begin{longtable}[]{@{}ll@{}}
@@ -261,6 +265,26 @@ a2 & b2\tabularnewline
 \bottomrule
 \end{longtable}
 
-This is the last paragraph, just to tie things up.
+\def\pandoctableshortcapt{}  % .unlisted
+
+\hypertarget{tbl:tbl-label9}{}
+\begin{longtable}[]{@{}ll@{}}
+\caption{\label{tbl:tbl-label9}This is the \emph{italicised long
+caption} of tbl9, which is \textbf{unlisted}, yet has a
+short-caption.}\tabularnewline
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endfirsthead
+\toprule
+cola & colb\tabularnewline
+\midrule
+\endhead
+a1 & b1\tabularnewline
+a2 & b2\tabularnewline
+\bottomrule
+\end{longtable}
+
+\undef\pandoctableshortcapt
 
 \end{document}

--- a/table-short-captions/sample.md
+++ b/table-short-captions/sample.md
@@ -27,7 +27,7 @@ Table: This is the *italicised long caption* of tbl2, which does not have a labe
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl3.  {#tbl:tbl-label3}
+Table: This is the *italicised long caption* of tbl3, which does not have a label, but does have an empty span at the end.  []{}
 
 
 | cola | colb |
@@ -35,7 +35,7 @@ Table: This is the *italicised long caption* of tbl3.  {#tbl:tbl-label3}
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl4, which is **unlisted**. This is expected usage.  {#tbl:tbl-label4 .unlisted}
+Table: This is the *italicised long caption* of tbl4, in standard `pandoc-crossref` form.  {#tbl:tbl-label4}
 
 
 | cola | colb |
@@ -43,7 +43,7 @@ Table: This is the *italicised long caption* of tbl4, which is **unlisted**. Thi
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl5, which has an **overriding** short-caption. This is the expected usage. {#tbl:tbl-label5 short-caption="Table 5 *short* capt."}
+Table: This is the *italicised long caption* of tbl5, which is improperly formatted, and will appear in the list of tables. This filter requires that `.unlisted` is placed in a span.  {#tbl:tbl-label5 .unlisted}
 
 
 | cola | colb |
@@ -51,7 +51,7 @@ Table: This is the *italicised long caption* of tbl5, which has an **overriding*
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl6, which is **unlisted**, yet has a short-caption.  {#tbl:tbl-label6 .unlisted short-caption="Table 6 **unlisted** *short* capt."}
+Table: This is the *italicised long caption* of tbl6, which has an empty short-caption. An empty short-caption does nothing. The long caption will still be used.  []{#tbl:tbl-label6 short-caption=""}
 
 
 | cola | colb |
@@ -59,7 +59,7 @@ Table: This is the *italicised long caption* of tbl6, which is **unlisted**, yet
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl7, which is **unlisted**, yet has a short-caption and other bogus classes {#tbl:tbl-label7 .unused-class .unlisted short-caption="Table 7 **unlisted** *short* capt." .more-classes}
+Table: This is the *italicised long caption* of tbl7, which is **unlisted**. This is expected usage.  []{#tbl:tbl-label7 .unlisted}
 
 
 | cola | colb |
@@ -67,7 +67,15 @@ Table: This is the *italicised long caption* of tbl7, which is **unlisted**, yet
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl8, which has an empty short-caption. An empty short-caption does nothing. The long caption will still be used. {#tbl:tbl-label8 short-caption=""}
+Table: This is the *italicised long caption* of tbl8, which has an **overriding** short-caption. This is the expected usage.  []{#tbl:tbl-label8 short-caption="Table 8 *short* capt."}
+
+
+| cola | colb |
+| ---- | ---- |
+| a1   | b1   |
+| a2   | b2   |
+
+Table: This is the *italicised long caption* of tbl9, which is **unlisted**, yet has a short-caption.  []{#tbl:tbl-label9 .unlisted short-caption="Table 9 **unlisted** *short* capt."}
 
 
 This is the last paragraph, just to tie things up.

--- a/table-short-captions/sample.md
+++ b/table-short-captions/sample.md
@@ -1,0 +1,73 @@
+---
+title: "Tests for table-short-captions.lua"
+lot: true
+---
+
+These tests are written so that if **bold font** appears in the LOT, something is wrong.
+
+
+| cola | colb |
+| ---- | ---- |
+| a1   | b1   |
+| a2   | b2   |
+
+Table: This is the *italicised long caption* of tbl1, which does not have a label.
+
+
+| cola | colb |
+| ---- | ---- |
+| a1   | b1   |
+| a2   | b2   |
+
+Table: This is the *italicised long caption* of tbl2, which does not have a label, but does have empty braces at the end.  {}
+
+
+| cola | colb |
+| ---- | ---- |
+| a1   | b1   |
+| a2   | b2   |
+
+Table: This is the *italicised long caption* of tbl3.  {#tbl:tbl-label3}
+
+
+| cola | colb |
+| ---- | ---- |
+| a1   | b1   |
+| a2   | b2   |
+
+Table: This is the *italicised long caption* of tbl4, which is **unlisted**. This is expected usage.  {#tbl:tbl-label4 .unlisted}
+
+
+| cola | colb |
+| ---- | ---- |
+| a1   | b1   |
+| a2   | b2   |
+
+Table: This is the *italicised long caption* of tbl5, which has an **overriding** short-caption. This is the expected usage. {#tbl:tbl-label5 short-caption="Table 5 *short* capt."}
+
+
+| cola | colb |
+| ---- | ---- |
+| a1   | b1   |
+| a2   | b2   |
+
+Table: This is the *italicised long caption* of tbl6, which is **unlisted**, yet has a short-caption.  {#tbl:tbl-label6 .unlisted short-caption="Table 6 **unlisted** *short* capt."}
+
+
+| cola | colb |
+| ---- | ---- |
+| a1   | b1   |
+| a2   | b2   |
+
+Table: This is the *italicised long caption* of tbl7, which is **unlisted**, yet has a short-caption and other bogus classes {#tbl:tbl-label7 .unused-class .unlisted short-caption="Table 7 **unlisted** *short* capt." .more-classes}
+
+
+| cola | colb |
+| ---- | ---- |
+| a1   | b1   |
+| a2   | b2   |
+
+Table: This is the *italicised long caption* of tbl8, which has an empty short-caption. An empty short-caption does nothing. The long caption will still be used. {#tbl:tbl-label8 short-caption=""}
+
+
+This is the last paragraph, just to tie things up.

--- a/table-short-captions/sample.md
+++ b/table-short-captions/sample.md
@@ -5,6 +5,10 @@ lot: true
 
 These tests are written so that if **bold font** appears in the LOT, something is wrong.
 
+The tests are split into two: expected uses, and non-standard uses/errors.  
+The non-standard uses are presented in this document for troubleshooting purposes, and to ensure the filter doesn't crash in corner cases.
+
+# Standard usage
 
 | cola | colb |
 | ---- | ---- |
@@ -19,7 +23,7 @@ Table: This is the *italicised long caption* of tbl1, which does not have a labe
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl2, which does not have a label, but does have empty braces at the end.  {}
+Table: This is the *italicised long caption* of tbl2, in standard `pandoc-crossref` form.  {#tbl:tbl-label2}
 
 
 | cola | colb |
@@ -27,7 +31,7 @@ Table: This is the *italicised long caption* of tbl2, which does not have a labe
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl3, which does not have a label, but does have an empty span at the end.  []{}
+Table: This is the *italicised long caption* of tbl3, which is **unlisted**.  []{#tbl:tbl-label3 .unlisted}
 
 
 | cola | colb |
@@ -35,7 +39,17 @@ Table: This is the *italicised long caption* of tbl3, which does not have a labe
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl4, in standard `pandoc-crossref` form.  {#tbl:tbl-label4}
+Table: This is the *italicised long caption* of tbl4, which has an **overriding** short-caption. This is the expected usage.  []{#tbl:tbl-label4 short-caption="Table 4 *short* capt."}
+
+
+# Non-standard usage/errors
+
+| cola | colb |
+| ---- | ---- |
+| a1   | b1   |
+| a2   | b2   |
+
+Table: This is the *italicised long caption* of tbl5, which does not have a label, but does have empty braces at the end.  {}
 
 
 | cola | colb |
@@ -43,7 +57,7 @@ Table: This is the *italicised long caption* of tbl4, in standard `pandoc-crossr
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl5, which is improperly formatted, and will appear in the list of tables. This filter requires that `.unlisted` is placed in a span.  {#tbl:tbl-label5 .unlisted}
+Table: This is the *italicised long caption* of tbl6, which does not have a label, but does have an empty span at the end.  []{}
 
 
 | cola | colb |
@@ -51,7 +65,7 @@ Table: This is the *italicised long caption* of tbl5, which is improperly format
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl6, which has an empty short-caption. An empty short-caption does nothing. The long caption will still be used.  []{#tbl:tbl-label6 short-caption=""}
+Table: This is the *italicised long caption* of tbl7, which is improperly formatted, and will appear in the list of tables. This filter requires that `.unlisted` is placed in a span.  {#tbl:tbl-label7 .unlisted}
 
 
 | cola | colb |
@@ -59,15 +73,7 @@ Table: This is the *italicised long caption* of tbl6, which has an empty short-c
 | a1   | b1   |
 | a2   | b2   |
 
-Table: This is the *italicised long caption* of tbl7, which is **unlisted**. This is expected usage.  []{#tbl:tbl-label7 .unlisted}
-
-
-| cola | colb |
-| ---- | ---- |
-| a1   | b1   |
-| a2   | b2   |
-
-Table: This is the *italicised long caption* of tbl8, which has an **overriding** short-caption. This is the expected usage.  []{#tbl:tbl-label8 short-caption="Table 8 *short* capt."}
+Table: This is the *italicised long caption* of tbl8, which has an empty short-caption. An empty short-caption does nothing. The long caption will still be used.  []{#tbl:tbl-label8 short-caption=""}
 
 
 | cola | colb |
@@ -76,6 +82,3 @@ Table: This is the *italicised long caption* of tbl8, which has an **overriding*
 | a2   | b2   |
 
 Table: This is the *italicised long caption* of tbl9, which is **unlisted**, yet has a short-caption.  []{#tbl:tbl-label9 .unlisted short-caption="Table 9 **unlisted** *short* capt."}
-
-
-This is the last paragraph, just to tie things up.

--- a/table-short-captions/table-short-captions.lua
+++ b/table-short-captions/table-short-captions.lua
@@ -86,7 +86,8 @@ local function parse_table_attrs(attr)
   -- If not unlisted, then find the property short-caption.
   local short_caption = nil
   if not unlisted then
-    if attr.attributes["short-caption"] and (#attr.attributes["short-caption"] > 0) then
+    if (attr.attributes["short-caption"]) and 
+       (#attr.attributes["short-caption"] > 0) then
       short_caption = pandoc.read(attr.attributes['short-caption']).blocks[1].c
     end
   end

--- a/table-short-captions/table-short-captions.lua
+++ b/table-short-captions/table-short-captions.lua
@@ -146,7 +146,7 @@ end
 --                 in header_includes
 function add_longtable_caption_mod(meta)
   local header_includes = -- test ? a : b
-    (meta['header-includes']) and (meta['header-includes'].t == 'MetaList')
+    (meta['header-includes'] and meta['header-includes'].t == 'MetaList')
     and meta['header-includes']
     or pandoc.MetaList{meta['header-includes']}
   header_includes[#header_includes + 1] =

--- a/table-short-captions/table-short-captions.lua
+++ b/table-short-captions/table-short-captions.lua
@@ -41,19 +41,6 @@ longtable_caption_mod = [[
 % -- end:latex-table-short-captions --
 ]]
 
---- Creates an (inclusive) slice of a table
--- @param tbl: The table to be sliced
--- @param first: The starting index
--- @param last: The ending index (inclusive)
--- @return (table): The sliced table
-function table.slice(tbl, first, last)
-  local sliced = {}
-  for i = first or 1, last or #tbl do
-    sliced[#sliced+1] = tbl[i]
-  end
-  return sliced
-end
-
 --- Creates a def shortcaption block to be placed before the table
 -- @param sc: nil or a List of RawInlines
 -- @return (Plain): The def shortcaption block

--- a/table-short-captions/table-short-captions.lua
+++ b/table-short-captions/table-short-captions.lua
@@ -145,12 +145,10 @@ end
 -- @treturn Meta : The document metadata, with replacement LaTeX macro
 --                 in header_includes
 function add_longtable_caption_mod(meta)
-  local header_includes
-  if meta['header-includes'] and meta['header-includes'].t == 'MetaList' then
-    header_includes = meta['header-includes']
-  else
-    header_includes = pandoc.MetaList{meta['header-includes']}
-  end
+  local header_includes = -- test ? a : b
+    (meta['header-includes']) and (meta['header-includes'].t == 'MetaList')
+    and meta['header-includes']
+    or pandoc.MetaList{meta['header-includes']}
   header_includes[#header_includes + 1] =
     pandoc.MetaBlocks{pandoc.RawBlock('tex', longtable_caption_mod)}
   meta['header-includes'] = header_includes

--- a/table-short-captions/table-short-captions.lua
+++ b/table-short-captions/table-short-captions.lua
@@ -123,7 +123,7 @@ end
 function rewrite_longtable_caption(tbl)
   -- Escape if there is no caption present.
   if not tbl.caption then
-    return {}
+    return nil
   end
 
   -- Try split the caption into (caption, properties)
@@ -139,7 +139,7 @@ function rewrite_longtable_caption(tbl)
 
   -- If we couldn't find brackets, escape.
   if not (_b and _e) then
-    return {}
+    return nil
   end
 
   -- Otherwise, bisect the caption

--- a/table-short-captions/table-short-captions.lua
+++ b/table-short-captions/table-short-captions.lua
@@ -1,6 +1,7 @@
---[[
-LaTeXTableShortCapts – enable .unlisted and short-caption="" properties on conversion to LaTeX
+---LaTeXTableShortCapts – enable `.unlisted` and `short-caption=""` properties 
+--                        for Pandoc conversion to LaTeX
 
+--[[
 Copyright (c) 2019 Blake Riley
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
@@ -22,7 +23,8 @@ if FORMAT ~= "latex" then
   return {}
 end
 
---- Code for injection into the LaTeX header, to overwrite a macro in longtable captions.
+--- Code for injection into the LaTeX header,
+--  to overwrite a macro in longtable captions.
 longtable_caption_mod = [[
 % -- begin:latex-table-short-captions --
 \makeatletter\AtBeginDocument{%
@@ -42,8 +44,8 @@ longtable_caption_mod = [[
 ]]
 
 --- Creates a def shortcaption block to be placed before the table
--- @param sc: nil or a List of RawInlines
--- @return (Plain): The def shortcaption block
+-- @tparam ?List[RawInlines] sc : The Pandoc-parsed shortcaption
+-- @treturn Plain : The def shortcaption block
 local function defshortcapt(sc)
   local scblock = List:new{}
   scblock:extend {pandoc.RawInline('tex', "\\def\\pandoctableshortcapt{")}
@@ -60,12 +62,15 @@ end
 --- The undef shortcaption block to be placed after the table
 local undefshortcapt = pandoc.RawBlock('tex', "\\undef\\pandoctableshortcapt")
 
---- Treats a Span's Attr as Table Attr, and extracts what is needed to build short-caption
--- @param (Attr): The Attr of the property Span in the table caption
--- @return[1] (nil or string): The identifier
--- @return[2] (nil or List of Inlines): The "short-caption" property if present, as a List of Inlines.
--- @return[3] (bool): Whether ".unlisted" appeared in the classes
-function parse_table_attrs(attr)
+--- Parses a mock "Table Attr".
+-- We use the Attr of an empty Span as if it were Table Attr.
+-- This function extracts what is needed to build a short-caption.
+-- @tparam Attr attr : The Attr of the property Span in the table caption
+-- @treturn ?string : The identifier
+-- @treturn ?List[Inlines] : The "short-caption" property, if present,
+--                           parsed by Pandoc to a List of Inlines.
+-- @treturn bool : Whether ".unlisted" appeared in the classes
+local function parse_table_attrs(attr)
   -- Find label
   local label = nil
   if attr.identifier and (#attr.identifier > 0) then
@@ -80,8 +85,7 @@ function parse_table_attrs(attr)
     end
   end
 
-  -- If not unlisted, then find the index of the property short-caption.
-  -- This does not attempt to parse all table properties, we ignore them.
+  -- If not unlisted, then find the property short-caption.
   local short_caption = nil
   if not unlisted then
     if attr.attributes["short-caption"] and (#attr.attributes["short-caption"] > 0) then
@@ -93,8 +97,9 @@ function parse_table_attrs(attr)
 end
 
 --- Wraps a table with shortcaption code
--- @param tbl (Table): The table with {}-wrapped properties in the caption
--- @return (List of Blocks): The table with {label} in the caption, optionally wrapped in shortcaption code
+-- @tparam Table tbl : The table with {}-wrapped properties in the caption
+-- @treturn List[Blocks] : The table with {label} in the caption, 
+--                         optionally wrapped in shortcaption code
 function rewrite_longtable_caption(tbl)
   -- Escape if there is no caption present.
   if not tbl.caption then
@@ -137,8 +142,9 @@ function rewrite_longtable_caption(tbl)
 end
 
 --- Inserts longtable_caption_mod into the header_includes
--- @param meta (Meta): The document metadata
--- @return (Meta): The document metadata, with latex function inserted in header_includes
+-- @tparam Meta meta : The document metadata
+-- @treturn Meta : The document metadata, with replacement LaTeX macro
+--                 in header_includes
 function add_longtable_caption_mod(meta)
   local header_includes
   if meta['header-includes'] and meta['header-includes'].t == 'MetaList' then

--- a/table-short-captions/table-short-captions.lua
+++ b/table-short-captions/table-short-captions.lua
@@ -44,13 +44,13 @@ longtable_caption_mod = [[
 ]]
 
 --- Creates a def shortcaption block to be placed before the table
--- @tparam ?List[RawInlines] sc : The Pandoc-parsed shortcaption
+-- @tparam ?string sc : The short-caption property value
 -- @treturn Plain : The def shortcaption block
 local function defshortcapt(sc)
   local scblock = List:new{}
   scblock:extend {pandoc.RawInline('tex', "\\def\\pandoctableshortcapt{")}
   if sc then
-    scblock:extend (sc)
+    scblock:extend (pandoc.read(sc).blocks[1].c)
   end
   scblock:extend {pandoc.RawInline('tex', "}")}
   if not sc then
@@ -67,8 +67,7 @@ local undefshortcapt = pandoc.RawBlock('tex', "\\undef\\pandoctableshortcapt")
 -- This function extracts what is needed to build a short-caption.
 -- @tparam Attr attr : The Attr of the property Span in the table caption
 -- @treturn ?string : The identifier
--- @treturn ?List[Inlines] : The "short-caption" property, if present,
---                           parsed by Pandoc to a List of Inlines.
+-- @treturn ?string : The "short-caption" property, if present.
 -- @treturn bool : Whether ".unlisted" appeared in the classes
 local function parse_table_attrs(attr)
   -- Find label
@@ -88,7 +87,7 @@ local function parse_table_attrs(attr)
   if not unlisted then
     if (attr.attributes["short-caption"]) and 
        (#attr.attributes["short-caption"] > 0) then
-      short_caption = pandoc.read(attr.attributes['short-caption']).blocks[1].c
+      short_caption = attr.attributes['short-caption']
     end
   end
 

--- a/table-short-captions/table-short-captions.lua
+++ b/table-short-captions/table-short-captions.lua
@@ -1,0 +1,198 @@
+--[[
+LaTeXTableShortCapts – enable .unlisted and short-caption="" properties on conversion to LaTeX
+
+Copyright (c) 2019 Blake Riley
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+]]
+local List = require 'pandoc.List'
+
+-- don't do anything unless we target latex
+if FORMAT ~= "latex" then
+  return {}
+end
+
+--- Code for injection into the LaTeX header, to overwrite a macro in longtable captions.
+longtable_caption_mod = [[
+% -- begin:latex-table-short-captions --
+\makeatletter\AtBeginDocument{%
+\def\LT@c@ption#1[#2]#3{%                 % Overwrite the workhorse macro used in formatting a longtable caption.
+  \LT@makecaption#1\fnum@table{#3}%
+  \ifdefined\pandoctableshortcapt         % If pandoctableshortcapt is defined (even if blank), we should override default behaviour.
+     \let\@tempa\pandoctableshortcapt%    % (Use let, we don't want to expand pandoctableshortcapt!)
+  \else                                   % If not, fall back to default behaviour
+     \def\@tempa{#2}%                     % (Use the argument in square brackets)
+  \fi
+  \ifx\@tempa\@empty\else                 % If @tempa is blank, no lot entry! Otherwise, @tempa becomes the lot title.
+     {\let\\\space
+     \addcontentsline{lot}{table}{\protect\numberline{\thetable}{\@tempa}}}%
+  \fi}
+}\makeatother
+% -- end:latex-table-short-captions --
+]]
+
+--- Creates an (inclusive) slice of a table
+-- @param tbl: The table to be sliced
+-- @param first: The starting index
+-- @param last: The ending index (inclusive)
+-- @return (table): The sliced table
+function table.slice(tbl, first, last)
+  local sliced = {}
+  for i = first or 1, last or #tbl do
+    sliced[#sliced+1] = tbl[i]
+  end
+  return sliced
+end
+
+--- Creates a def shortcaption block to be placed before the table
+-- @param sc: nil or a List of RawInlines
+-- @return (Plain): The def shortcaption block
+local function defshortcapt(sc)
+  local scblock = List:new{}
+  scblock:extend {pandoc.RawInline('tex', "\\def\\pandoctableshortcapt{")}
+  if sc then
+    scblock:extend (sc)
+  end
+  scblock:extend {pandoc.RawInline('tex', "}")}
+  if not sc then
+    scblock:extend {pandoc.RawInline('tex', "  % .unlisted")}
+  end
+  return pandoc.Plain(scblock)
+end
+
+--- The undef shortcaption block to be placed after the table
+local undefshortcapt = pandoc.RawBlock('tex', "\\undef\\pandoctableshortcapt")
+
+--- Search through a messy list of pandoc-parsed Inlines into what we need to build short-caption
+-- @param (List of Inlines): A mess of Inlines containing the table properties
+-- @return[1] (nil or string): The first word starting with "#tbl:"
+-- @return[2] (nil or List of Inlines): The "short-caption" property if present, as a List of Inlines.
+-- @return[3] (bool): Whether ".unlisted" appeared in the properties
+function parse_table_properties(props)
+  -- Flatten the string, because this will make our job much easier (except for short-caption hunting)
+  local flatprops = pandoc.utils.stringify(props)
+
+  -- Find label
+  local label = flatprops:match("(#tbl:%g-)%s")
+
+  -- Find classes, particularly look for ".unlisted"
+  local unlisted = false
+  classes = flatprops:gmatch("(%.[%w%-]-)[%s}]")
+  for c in classes do
+    if c == ".unlisted" then
+      unlisted = true
+    end
+  end
+
+  -- If not unlisted, then find the index of the property short-caption.
+  -- This does not attempt to parse all table properties, we ignore them.
+  local short_caption = nil
+  if not unlisted then
+    -- Try to find that index
+    local has_short_caption = function(inl)
+      return inl.text and (inl.text:match("short%-caption=\"?"))
+    end
+    local _, idx_sc = props:find_if(has_short_caption)
+
+    -- We're really interested in the next Inline.
+    -- If the next Inline exists, and is a "Quoted" type, this is our short caption, otherwise ignore it.
+    if idx_sc and props[idx_sc+1] then
+      maybe_sc = props[idx_sc+1]
+      if maybe_sc.t == "Quoted" then
+        short_caption = maybe_sc.content
+      end
+    end
+  end
+
+  return label, short_caption, unlisted
+end
+
+--- Wraps a table with shortcaption code
+-- @param tbl (Table): The table with {}-wrapped properties in the caption
+-- @return (List of Blocks): The table with {label} in the caption, optionally wrapped in shortcaption code
+function rewrite_longtable_caption(tbl)
+  -- Escape if there is no caption present.
+  if not tbl.caption then
+    return {}
+  end
+
+  -- Try split the caption into (caption, properties)
+  local has_start_bracket = function (inl)
+    return inl.text and (inl.text:sub(1, 1) == "{")
+  end
+  local has_end_bracket = function (inl)
+    return inl.text and (inl.text:sub(#inl.text, -1) == "}")
+  end
+
+  local _b, idx_left = tbl.caption:find_if(has_start_bracket)
+  local _e, idx_right = tbl.caption:find_if(has_end_bracket)
+
+  -- If we couldn't find brackets, escape.
+  if not (_b and _e) then
+    return {}
+  end
+
+  -- Otherwise, bisect the caption
+  local long_caption = table.slice(tbl.caption, 1, idx_left-1)
+  local props        = table.slice(tbl.caption, idx_left, idx_right)
+
+  -- Tidy up long_caption
+  if long_caption[#long_caption] == pandoc.Space() then
+    table.remove(long_caption)
+  end
+
+  -- Parse it all
+  long_caption = List:new(long_caption)
+  props = List:new(props)
+  local label, short_caption, unlisted = parse_table_properties(props)
+
+  -- Put label back into caption for pandoc-crossref
+  
+  if label then
+    long_caption:extend {pandoc.Space(), pandoc.Str("{"..label.."}")}
+  end
+
+  -- Place new table
+  local result = List:new{}
+  if short_caption or unlisted then
+    result:extend {defshortcapt(short_caption)}
+  end
+  result:extend {pandoc.Table(long_caption, tbl.aligns, tbl.widths, tbl.headers, tbl.rows)}
+  if short_caption or unlisted then
+    result:extend {undefshortcapt}
+  end
+  return result
+end
+
+--- Inserts longtable_caption_mod into the header_includes
+-- @param meta (Meta): The document metadata
+-- @return (Meta): The document metadata, with latex function inserted in header_includes
+function add_longtable_caption_mod(meta)
+  local header_includes
+  if meta['header-includes'] and meta['header-includes'].t == 'MetaList' then
+    header_includes = meta['header-includes']
+  else
+    header_includes = pandoc.MetaList{meta['header-includes']}
+  end
+  header_includes[#header_includes + 1] =
+    pandoc.MetaBlocks{pandoc.RawBlock('tex', longtable_caption_mod)}
+  meta['header-includes'] = header_includes
+  return meta
+end
+
+return {
+  {
+    Meta = add_longtable_caption_mod,
+    Table = rewrite_longtable_caption,
+  }
+}

--- a/table-short-captions/table-short-captions.lua
+++ b/table-short-captions/table-short-captions.lua
@@ -79,10 +79,8 @@ local function parse_table_attrs(attr)
 
   -- Look for ".unlisted" in classes
   local unlisted = false
-  for _, c in ipairs(attr.classes) do
-    if c == "unlisted" then
-      unlisted = true
-    end
+  if attr.classes:includes("unlisted") then
+    unlisted = true
   end
 
   -- If not unlisted, then find the property short-caption.


### PR DESCRIPTION
Tables in Markdown do not come with attributes (under the current AST), and there is no way to alter the `\caption{}` command written by Pandoc for tables in LaTeX.

- I was able to modify the behaviour of the caption command within a longtable, so that we can use the functionality of `\caption[short]{long}`. This was done by replacing one of the `\longtable` internal commands: `\LT@c@ption`.
This longtable macro now checks for a macro `\pandoctableshortcapt` when expanding the caption. It will use this custom macro in place of whatever is in the square brackets in `\caption[short]{long}`, even if there were no square brackets.
- After putting that macro overwrite in the header, the filter parses the caption of a Table.
  - If it finds a `short-caption` attribute, it places RawBlocks around the Table to define and undefine `\pandoctableshortcapt` appropriately.
  - If it finds a `.unlisted` class, it places RawBlocks around the Table to define `\pandoctableshortcapt` as `{}`. This causes the `\LT@c@ption` macro to not write an entry to the lof.

I've done a little bit of testing, and it seems to work nicely.

I have no idea how robust it is though, particularly to other changes in the header-includes.