### PR TITLE
fix for #50 caused by latex package changes v3.x

### DIFF
--- a/track-changes/track-changes.lua
+++ b/track-changes/track-changes.lua
@@ -13,17 +13,20 @@ local function is_wordprocessing (format)
 end
 
 header_track_changes = [[
-\usepackage[markup=underlined,authormarkup=none]{changes}
+\PassOptionsToPackage{textsize=scriptsize}{todonotes}
+\usepackage[markup=underlined,authormarkup=none,commentmarkup=todo]{changes}
 \definecolor{auth1}{HTML}{4477AA}
 \definecolor{auth2}{HTML}{117733}
 \definecolor{auth3}{HTML}{999933}
 \definecolor{auth4}{HTML}{CC6677}
 \definecolor{auth5}{HTML}{AA4499}
 \definecolor{auth6}{HTML}{332288}
-\usepackage[textsize=scriptsize]{todonotes}
 \setlength{\marginparwidth}{3cm}
 \makeatletter
-\setremarkmarkup{\todo[color=Changes@Color#1!20]{\sffamily\textbf{#1:}~#2}}
+\@ifpackagelater{changes}{2018/11/03}{%
+}{%
+  \setremarkmarkup{\todo[color=Changes@Color#1!20]{\sffamily\textbf{#1:}~#2}}
+}%
 \makeatother
 \newcommand{\note}[2][]{\added[#1,remark={#2}]{}}
 \newcommand\hlnotesingle{%
@@ -208,7 +211,7 @@ function Pandoc(doc)
     tc = type(meta['trackChanges']) == 'table' and pandoc.utils.stringify(meta['trackChanges']) or meta['trackChanges'] or 'accept'
     local trackChanges = PANDOC_READER_OPTIONS and PANDOC_READER_OPTIONS.trackChanges or trackChangesOptions[tc]
     meta.trackChanges = nil -- remove it from the matadata
-
+    
     local M = {}
     if trackChanges == 'AllChanges' then
         if is_html(FORMAT) then


### PR DESCRIPTION
The latex package changes v3.x now loads the todonotes package by itself. That caused the option clash. This new version of the lua filter now requires changes v3.x.