### PR TITLE
center images filter

### DIFF
--- a/centerimage/Makefile
+++ b/centerimage/Makefile
@@ -1,0 +1,11 @@
+DIFF ?= diff --strip-trailing-cr -u
+
+test:
+	@pandoc --lua-filter=centerimage.lua sample.md -t latex | $(DIFF) expected.latex -
+
+.PHONY: test
+
+debug:
+	@pandoc --lua-filter=centerimage.lua sample.md -t latex
+
+.PHONY: debug

--- a/centerimage/README.md
+++ b/centerimage/README.md
@@ -1,0 +1,9 @@
+# centerimage
+
+This filter centers images when converting markdown to LaTeX.
+It is based on the TeX answer [here.](https://tex.stackexchange.com/questions/46903/centering-with-includegraphics-not-with-beginfigure)
+
+Run the filter by passing it to pandoc with the `--lua-filter` flag:
+```
+$ pandoc --lua-filter centerimage.lua myfile.md -o myfile.latex
+```

--- a/centerimage/centerimage.lua
+++ b/centerimage/centerimage.lua
@@ -1,8 +1,7 @@
 -- wrap images with a centering LaTeX snippet
 -- https://tex.stackexchange.com/questions/46903/centering-with-includegraphics-not-with-beginfigure
 function Image(elem)
-	local List = require 'pandoc.List'
-  return List:new{
+  return {
 		pandoc.RawInline('latex', '{\\centering'),
 		elem,
 		pandoc.RawInline('latex', '\\par}')

--- a/centerimage/centerimage.lua
+++ b/centerimage/centerimage.lua
@@ -1,0 +1,10 @@
+-- wrap images with a centering LaTeX snippet
+-- https://tex.stackexchange.com/questions/46903/centering-with-includegraphics-not-with-beginfigure
+function Image(elem)
+	local List = require 'pandoc.List'
+  return List:new{
+		pandoc.RawInline('latex', '{\\centering'),
+		elem,
+		pandoc.RawInline('latex', '\\par}')
+  }
+end

--- a/centerimage/centerimage.lua
+++ b/centerimage/centerimage.lua
@@ -2,8 +2,8 @@
 -- https://tex.stackexchange.com/questions/46903/centering-with-includegraphics-not-with-beginfigure
 function Image(elem)
   return {
-		pandoc.RawInline('latex', '{\\centering'),
-		elem,
-		pandoc.RawInline('latex', '\\par}')
+    pandoc.RawInline('latex', '{\\centering'),
+    elem,
+    pandoc.RawInline('latex', '\\par}')
   }
 end

--- a/centerimage/expected.latex
+++ b/centerimage/expected.latex
@@ -1,0 +1,3 @@
+some text
+{\centering\includegraphics[width=2in,height=\textheight]{logo.png}\par}
+some other text

--- a/centerimage/sample.md
+++ b/centerimage/sample.md
@@ -1,0 +1,3 @@
+some text
+![](logo.png){width="2.0in"}
+some other text


### PR DESCRIPTION
Center images when converting from markdown to LaTeX
Following up from my comment in https://github.com/pandoc/lua-filters/pull/66