### PR TITLE
Use absolute directories for temp files given to inkscape.

### DIFF
--- a/diagram-generator/diagram-generator.lua
+++ b/diagram-generator/diagram-generator.lua
@@ -93,9 +93,10 @@ end
 local function tikz2image(src, filetype, additionalPackages)
 
     -- Define file names:
-    local outfile = string.format("./tmp-latex/file.%s", filetype)
-    local tmp = "./tmp-latex/file"
-    local tmpDir = "./tmp-latex/"
+    local cwd = os.getenv("PWD")
+    local outfile = string.format("%s/tmp-latex/file.%s", cwd, filetype)
+    local tmp = string.format("%s/tmp-latex/file", cwd)
+    local tmpDir = string.format("%s/tmp-latex/", cwd)
 
     -- Ensure, that the tmp directory exists:
     os.execute("mkdir -p tmp-latex")


### PR DESCRIPTION
Inkscape on Mac has a weird relocation problem:
/usr/local/bin/inkscape will typically be a script to cd into a
different directory.  Relative paths break.  I know this works on
POSIX-like systems, but I'm not so sure about Windows.