### PR TITLE
Add list indices to institutes

### DIFF
--- a/scholarly-metadata/expected.md
+++ b/scholarly-metadata/expected.md
@@ -22,10 +22,13 @@ author:
 institute:
 - address: '23 Science Street, Eureka, Mississippi, USA'
   id: fosg
+  index: 1
   name: Formatting Open Science Group
 - id: fop
+  index: 2
   name: Federation of Planets
 - id: Acme Corporation
+  index: 3
   name: Acme Corporation
 ---
 

--- a/scholarly-metadata/scholarly-metadata.lua
+++ b/scholarly-metadata/scholarly-metadata.lua
@@ -158,6 +158,12 @@ local function canonicalize(raw_author, raw_institute)
     merge_on_id(institutes, inst)
   end
 
+  
+  -- Add list indices to institutes for numbering and reference purposes
+  for idx, inst in ipairs(institutes) do
+    inst.index = pandoc.MetaInlines{pandoc.Str(tostring(idx))}
+  end
+  
   -- replace institutes with their indices
   local to_index = function (inst)
     return tostring(select(2, institutes:find_if(has_id(inst.id))))


### PR DESCRIPTION
Problem: We get the institutes per author as numeric indices, which is fine. But as we cannot enumerate in pandoc template $for loops, it is not trivial to link or reference against the institutes. Basically we cannot get a hold of the institutes index in pandoc template language.

Solution: Adding the index of the institute to the institute-object helps in getting this references straight. Now we can write, for example, a html-template and make use of anchor-links and id's.