### PR TITLE
lilypond: fix handling of non-LilyPond code elements

### DIFF
--- a/lilypond/Makefile
+++ b/lilypond/Makefile
@@ -1,6 +1,6 @@
 DIFF ?= diff --strip-trailing-cr -u
 
-test: test-appoggiaturas test-oboe
+test: test-appoggiaturas test-oboe test-code
 
 test-appoggiaturas:
 	@{ pandoc --lua-filter=lilypond.lua -t html appoggiaturas.md \
@@ -13,5 +13,9 @@ test-oboe:
 	test -e oboe.png && \
 	test -e b-flat.png
 
+test-code:
+	@pandoc --lua-filter=lilypond.lua -t html code.md \
+		| $(DIFF) code.html.expected -
 
-.PHONY: test test-appoggiaturas test-oboe
+
+.PHONY: test test-appoggiaturas test-oboe test-code

--- a/lilypond/code.html.expected
+++ b/lilypond/code.html.expected
@@ -1,0 +1,6 @@
+<p>The filter should leave code elements (like this: <code>putStrLn "hello, world!"</code>) and code blocks (like this:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode lua"><code class="sourceCode lua"><span id="cb1-1"><a href="#cb1-1"></a><span class="kw">function</span> foo<span class="op">()</span></span>
+<span id="cb1-2"><a href="#cb1-2"></a>  <span class="cf">return</span> <span class="st">&quot;foo&quot;</span></span>
+<span id="cb1-3"><a href="#cb1-3"></a><span class="cf">end</span></span></code></pre></div>
+<p>) alone if they aren’t tagged with the <code>lilypond</code> class.</p>
+<p>It should also ignore elements that have the <code>ly-norender</code> class: <code class="sourceCode lilypond">relative c&#39;</code>.</p>

--- a/lilypond/code.md
+++ b/lilypond/code.md
@@ -1,0 +1,13 @@
+The filter should leave code elements (like this: `putStrLn "hello, world!"`)
+and code blocks (like this:
+
+```lua
+function foo()
+  return "foo"
+end
+```
+
+) alone if they aren't tagged with the `lilypond` class.
+
+It should also ignore elements that have the `ly-norender` class: `relative
+c'`{.lilypond .ly-norender}.


### PR DESCRIPTION
The lilypond filter previously handled non-LilyPond code blocks erroneously, causing them to be omitted from the output under some circumstances. This PR fixes this issue and adds a corresponding regression test (see `code.md`). Sorry for the silly mistake!

(Incidentally, the bare comparison `PANDOC_VERSION == "2.7.3"` continues not to work with my installation of pandoc v2.7.3, for unknown reasons, so I've reverted to the `tostring` version.)