### PR TITLE
lilypond: Add missing 'local' qualifier

### DIFF
--- a/lilypond/lilypond.lua
+++ b/lilypond/lilypond.lua
@@ -88,7 +88,7 @@ local function generate_image(name, input, dpi, whither)
   return whither .. "/" .. fullname
 end
 
-function make_relative_path(to, from)
+local function make_relative_path(to, from)
   return pandoc.pipe(
            "realpath",
            {"--relative-to=" .. from, to},


### PR DESCRIPTION
Add a `local` qualifier that was missing from the signature of `make_relative_path`, for consistency with the rest of the file. (Only because it was bothering me, not because it makes any practical difference.)