### PR TITLE
Match any non-whitespace in aspell output

### DIFF
--- a/spellcheck/spellcheck.lua
+++ b/spellcheck/spellcheck.lua
@@ -30,7 +30,7 @@ local function run_spellcheck(lang)
   end
   local inp = table.concat(keys, '\n')
   local outp = pandoc.pipe('aspell', {'list','-l',lang}, inp)
-  for w in string.gmatch(outp, "(%a*)\n") do
+  for w in string.gmatch(outp, "([%S]+)\n") do
     io.write(w)
     if lang ~= deflang then
       io.write("\t[" .. lang .. "]")


### PR DESCRIPTION
Closes #90

aspell (version 0.60.7) trims leading and trailing punctuation.  Running aspell on the following text file with intentional misspellings:
```
dogsxyz, catsxyz, and ferretsxyz.
'bearsxyz' and "wolvesxyz"?
micexyz-batsxyz or -tigers'xyz!
```

produces the output:
```
dogsxyz
catsxyz
ferretsxyz
bearsxyz
wolvesxyz
micexyz
batsxyz
tigers'xyz
```