### PR TITLE
Add asciidoc format to pagebreak.lua

### DIFF
--- a/pagebreak/Makefile
+++ b/pagebreak/Makefile
@@ -1,6 +1,9 @@
 DIFF ?= diff --strip-trailing-cr -u
 
-test: test-html test-md
+test: test-asciidoc test-html test-md 
+
+test-asciidoc:
+	@pandoc --lua-filter=pagebreak.lua sample.md --to asciidoc | $(DIFF) expected.adoc -
 
 test-html:
 	@pandoc --lua-filter=pagebreak.lua sample.md | $(DIFF) expected.html -
@@ -8,4 +11,4 @@ test-html:
 test-md:
 	@pandoc -t ms --lua-filter=pagebreak.lua sample.md | $(DIFF) expected.ms -
 
-.PHONY: test test-html test-md
+.PHONY: test test-asciidoc test-html test-md 

--- a/pagebreak/expected.adoc
+++ b/pagebreak/expected.adoc
@@ -1,0 +1,14 @@
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec
+hendrerit tempor tellus. Donec pretium posuere tellus.
+
+<<<
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+ridiculus mus. Nulla posuere. Donec vitae dolor.
+
+<<<
+
+Pellentesque dapibus suscipit ligula. Donec posuere augue in quam.
+Suspendisse potenti.
+
+Final paragraph without a preceding pagebreak.

--- a/pagebreak/pagebreak.lua
+++ b/pagebreak/pagebreak.lua
@@ -23,13 +23,13 @@ end
 
 --- configs – these are populated in the Meta filter.
 local pagebreak = {
+  asciidoc = '<<<\n\n',
   epub = '<p style="page-break-after: always;"> </p>',
   html = '<div style="page-break-after: always;"></div>',
   latex = '\\newpage{}',
   ms = '.bp',
   ooxml = '<w:p><w:r><w:br w:type="page"/></w:r></w:p>',
-  odt = '<text:p text:style-name="Pagebreak"/>',
-  asciidoc = '<<<\n\n'
+  odt = '<text:p text:style-name="Pagebreak"/>'
 }
 
 local function pagebreaks_from_config (meta)

--- a/pagebreak/pagebreak.lua
+++ b/pagebreak/pagebreak.lua
@@ -28,7 +28,8 @@ local pagebreak = {
   latex = '\\newpage{}',
   ms = '.bp',
   ooxml = '<w:p><w:r><w:br w:type="page"/></w:r></w:p>',
-  odt = '<text:p text:style-name="Pagebreak"/>'
+  odt = '<text:p text:style-name="Pagebreak"/>',
+  asciidoc = '<<<\n\n'
 }
 
 local function pagebreaks_from_config (meta)
@@ -61,6 +62,8 @@ local function newpage(format)
     return pandoc.RawBlock('html', pagebreak.epub)
   elseif format:match 'ms' then
     return pandoc.RawBlock('ms', pagebreak.ms)
+  elseif format:match 'asciidoc' then
+    return pandoc.RawBlock('asciidoc', pagebreak.asciidoc)
   else
     -- fall back to insert a form feed character
     return pandoc.Para{pandoc.Str '\f'}


### PR DESCRIPTION
For asciidoc and asciidoctor format, pagebrek.lua is updated.
Syntax is from AsciiDoc Syntax Quick Reference.
https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#breaks
Currently, RawBlock in AsciiDoc Writer does not add new lines. So, this update have "\n\n" to separate paragraphs.