### PR TITLE
Add groff ms format support to pagebreak.lua.

### DIFF
--- a/pagebreak/Makefile
+++ b/pagebreak/Makefile
@@ -1,6 +1,11 @@
 DIFF ?= diff --strip-trailing-cr -u
 
-test:
+test: test-html test-md
+
+test-html:
 	@pandoc --lua-filter=pagebreak.lua sample.md | $(DIFF) expected.html -
 
-.PHONY: test
+test-md:
+	@pandoc -t ms --lua-filter=pagebreak.lua sample.md | $(DIFF) expected.ms -
+
+.PHONY: test test-html test-md

--- a/pagebreak/README.md
+++ b/pagebreak/README.md
@@ -20,6 +20,7 @@ Usage
 Fully supported output formats are:
 
 - Docx,
+- groff ms,
 - LaTeX,
 - HTML, and
 - EPUB.

--- a/pagebreak/expected.ms
+++ b/pagebreak/expected.ms
@@ -1,0 +1,17 @@
+.LP
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+Donec hendrerit tempor tellus.
+Donec pretium posuere tellus.
+.bp
+.PP
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+ridiculus mus.
+Nulla posuere.
+Donec vitae dolor.
+.bp
+.PP
+Pellentesque dapibus suscipit ligula.
+Donec posuere augue in quam.
+Suspendisse potenti.
+.PP
+Final paragraph without a preceding pagebreak.

--- a/pagebreak/pagebreak.lua
+++ b/pagebreak/pagebreak.lua
@@ -26,6 +26,7 @@ local pagebreak = {
   epub = '<p style="page-break-after: always;"> </p>',
   html = '<div style="page-break-after: always;"></div>',
   latex = '\\newpage{}',
+  ms = '.bp',
   ooxml = '<w:p><w:r><w:br w:type="page"/></w:r></w:p>',
   odt = '<text:p text:style-name="Pagebreak"/>'
 }
@@ -58,6 +59,8 @@ local function newpage(format)
     return pandoc.RawBlock('html', pagebreak.html)
   elseif format:match 'epub' then
     return pandoc.RawBlock('html', pagebreak.epub)
+  elseif format:match 'ms' then
+    return pandoc.RawBlock('ms', pagebreak.ms)
   else
     -- fall back to insert a form feed character
     return pandoc.Para{pandoc.Str '\f'}


### PR DESCRIPTION
The way {g,t}roff works is that the macro, `.bp`, has to be on a line by itself. Since we are creating a RawBlock, I think that is implied.