### PR TITLE
include-files: fixed expected-auto.native makefile target.

### DIFF
--- a/include-files/Makefile
+++ b/include-files/Makefile
@@ -10,6 +10,6 @@ expected.native: sample.md file-a.md file-b.md file-c.md include-files.lua
 	pandoc --lua-filter=include-files.lua --output $@ $<
 
 expected-auto.native: sample.md file-a.md file-b.md file-c.md include-files.lua
-	pandoc --lua-filter=include-files.lua --output $@ $<
+	pandoc --lua-filter=include-files.lua -M include-auto --output $@ $<
 
 .PHONY: test


### PR DESCRIPTION
I think the `include-auto` has been forgotten in the creation of the `expected-auto.native` file.