### PR TITLE
Include files extension specific PR

### DIFF
--- a/include-files/Makefile
+++ b/include-files/Makefile
@@ -1,12 +1,12 @@
 DIFF ?= diff --strip-trailing-cr -u
 
-test: sample.md file-a.md file-b.md file-c.md include-files.lua
+test: sample.md file-a.md file-b.md file-c.md shell1 shell2 include-files.lua
 	@pandoc --lua-filter=include-files.lua --to=native $< \
 	    | $(DIFF) expected.native -
 	@pandoc --lua-filter=include-files.lua -M include-auto --to=native $< \
 	    | $(DIFF) expected-auto.native -
 
-expected.native: sample.md file-a.md file-b.md file-c.md include-files.lua
+expected.native: sample.md file-a.md file-b.md file-c.md shell1 shell2 include-files.lua
 	pandoc --lua-filter=include-files.lua --output $@ $<
 
 expected-auto.native: sample.md file-a.md file-b.md file-c.md include-files.lua

--- a/include-files/README.md
+++ b/include-files/README.md
@@ -11,6 +11,9 @@ document.
 
 Metadata from included files is discarded.
 
+Add class `source` to include files as normal code blocks taken from
+files instead of text in same format as the input.
+
 ### Shifting Headings
 
 The default is to include the subdocuments unchanged, but it can
@@ -59,6 +62,9 @@ will want to include files written in a different format. An
 alternative format can be specified via the `format` attribute.
 Only plain-text formats are accepted.
 
+In order to include source code block from files use additional class
+`source` instead of trying the language as `format`.
+
 ### Recursive transclusion
 
 Included files can in turn include other files. Note that all
@@ -99,6 +105,13 @@ some additional information in the main file `main.md`:
     // headings in included documents are shifted down a level,
     // a level 1 heading becomes level 2.
     appendix/questionaire.md
+    ```
+
+    ## Source code
+
+    ``` {.include .source .lua}
+    // code of this nice filter
+    include-files.lua
     ```
 
 An HTML can be produced with this command:

--- a/include-files/expected-auto.native
+++ b/include-files/expected-auto.native
@@ -16,6 +16,8 @@
 ,Para [Str "This",Space,Str "is",Space,Code ("",[],[]) "file-a.md",Str "."]
 ,Header 3 ("title-of-file-a",[],[]) [Str "Title",Space,Str "of",Space,Str "file-a"]
 ,Para [Str "This",Space,Str "is",Space,Code ("",[],[]) "file-a.md",Str "."]
+,Header 1 ("source-code",[],[]) [Str "Source",Space,Str "code"]
+,CodeBlock ("",["include","source","bash"],[]) "#!/bin/bash\n\necho \"Hello World !\"\n\n#!/bin/bash\nfor i in \"Hello \" \"World \" \"!\\n\" \ndo\n\tprintf \"$i\"\ndone\n\n"
 ,Header 1 ("appendix",[],[]) [Str "Appendix"]
 ,Para [Str "More",Space,Str "info",Space,Str "goes",Space,Str "here."]
 ,Header 2 ("questionaire",[],[]) [Str "Questionaire"]

--- a/include-files/expected.native
+++ b/include-files/expected.native
@@ -16,6 +16,8 @@
 ,Para [Str "This",Space,Str "is",Space,Code ("",[],[]) "file-a.md",Str "."]
 ,Header 2 ("title-of-file-a",[],[]) [Str "Title",Space,Str "of",Space,Str "file-a"]
 ,Para [Str "This",Space,Str "is",Space,Code ("",[],[]) "file-a.md",Str "."]
+,Header 1 ("source-code",[],[]) [Str "Source",Space,Str "code"]
+,CodeBlock ("",["include","source","bash"],[]) "#!/bin/bash\n\necho \"Hello World !\"\n\n#!/bin/bash\nfor i in \"Hello \" \"World \" \"!\\n\" \ndo\n\tprintf \"$i\"\ndone\n\n"
 ,Header 1 ("appendix",[],[]) [Str "Appendix"]
 ,Para [Str "More",Space,Str "info",Space,Str "goes",Space,Str "here."]
 ,Header 2 ("questionaire",[],[]) [Str "Questionaire"]

--- a/include-files/include-files.lua
+++ b/include-files/include-files.lua
@@ -1,4 +1,4 @@
---- include-files.lua – filter to include Markdown files
+--- include-files.lua – filter to include files
 ---
 --- Copyright: © 2019–2020 Albert Krewinkel
 --- License:   MIT – see LICENSE file for details

--- a/include-files/include-files.lua
+++ b/include-files/include-files.lua
@@ -53,8 +53,8 @@ function transclude (cb)
            io.stderr:write("Cannot open file " .. line .. " | Skipping includes\n")
          else
            contents = contents .. fh:read('*a')
+           fh:close()
          end
-         fh:close()
       end
     end
     return pandoc.CodeBlock(contents, cb.attr)

--- a/include-files/include-files.lua
+++ b/include-files/include-files.lua
@@ -43,6 +43,22 @@ function transclude (cb)
   if not cb.classes:includes 'include' then
     return
   end
+  -- process files as source code blocks
+  if cb.classes:includes 'source' then
+     local contents = ""
+     for line in cb.text:gmatch('[^\n]+') do
+       if line:sub(1,2) ~= '//' then
+         local fh = io.open(line)
+         if not fh then
+           io.stderr:write("Cannot open file " .. line .. " | Skipping includes\n")
+         else
+           contents = contents .. fh:read('*a')
+         end
+         fh:close()
+      end
+    end
+    return pandoc.CodeBlock(contents, cb.attr)
+  end
 
   -- Markdown is used if this is nil.
   local format = cb.attributes['format']

--- a/include-files/sample.md
+++ b/include-files/sample.md
@@ -28,6 +28,14 @@ file-d.org
 file-f.md
 ```
 
+# Source code
+
+``` {.include .source .bash}
+// this will include simple bash files
+shell1
+shell2
+```
+
 # Appendix
 
 More info goes here.

--- a/include-files/shell1
+++ b/include-files/shell1
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Hello World !"
+

--- a/include-files/shell2
+++ b/include-files/shell2
@@ -1,0 +1,6 @@
+#!/bin/bash
+for i in "Hello " "World " "!\n" 
+do
+	printf "$i"
+done
+


### PR DESCRIPTION
In order to facilitate an eventual inclusion of code as commented in PR #126 I modified my fork and created distincts PR.

This one includes a modification of the `include-files` filter to enable inclusion of source code files.