### PR TITLE
include-code-files: overlong line reduction in doc

### DIFF
--- a/include-code-files/README.md
+++ b/include-code-files/README.md
@@ -2,7 +2,8 @@
 
 Filter to include code from source files.
 
-The filter is largely inspired by [pandoc-include-code](https://github.com/owickstrom/pandoc-include-code).
+The filter is largely inspired by
+[pandoc-include-code](https://github.com/owickstrom/pandoc-include-code).
 
 ## Usage
 


### PR DESCRIPTION
As commented in #130 (comment)