### PR TITLE
Fix table-short-captions support for Pandoc 2.10+

### DIFF
--- a/table-short-captions/Makefile
+++ b/table-short-captions/Makefile
@@ -20,6 +20,6 @@ sample.pdf: sample.md
 	@pandoc -s $(LF) $(F) -t latex $< -o $@
 
 clean:
-	rm -v *.aux *.dvi *.fdb_latexmk *.fls *.log *.lot *.ps *.pdf sample.tex | true
+	rm -fv *.aux *.dvi *.fdb_latexmk *.fls *.log *.lot *.ps *.pdf sample.tex
 
 .PHONY: test test-with-crossref clean

--- a/table-short-captions/test-table-short-captions-crossref.sh
+++ b/table-short-captions/test-table-short-captions-crossref.sh
@@ -50,7 +50,7 @@ assert_contains <<EOF
 caption} of tbl3, which is \textbf{unlisted}.}\tabularnewline
 EOF
 assert_contains <<EOF
-\undef\pandoctableshortcapt
+\let\pandoctableshortcapt\relax
 EOF
 
 # Test 4
@@ -66,7 +66,7 @@ caption} of tbl4, which has an \textbf{overriding} short-caption. This
 is the expected usage.}\tabularnewline
 EOF
 assert_contains <<EOF
-\undef\pandoctableshortcapt
+\let\pandoctableshortcapt\relax
 EOF
 
 # Test 5
@@ -115,5 +115,5 @@ caption} of tbl9, which is \textbf{unlisted}, yet has a
 short-caption.}\tabularnewline
 EOF
 assert_contains <<EOF
-\undef\pandoctableshortcapt
+\let\pandoctableshortcapt\relax
 EOF

--- a/table-short-captions/test-table-short-captions-crossref.sh
+++ b/table-short-captions/test-table-short-captions-crossref.sh
@@ -4,9 +4,10 @@ latex_result="$(cat -)"
 
 assert_contains ()
 {
-    printf '%s' "$latex_result" | grep -qF "$1" -
+    content="$(cat -)"
+    printf '%s' "$latex_result" | grep -qF "$content" -
     if [ $? -ne 0 ]; then
-        printf 'Output does not contain `%s`.\n' "$1" >&2
+        printf 'Output does not contain `%s`.\n' "$content" >&2
         exit 1
     fi
 }

--- a/table-short-captions/test-table-short-captions.sh
+++ b/table-short-captions/test-table-short-captions.sh
@@ -46,7 +46,7 @@ assert_contains <<EOF
 \textbf{unlisted}. \{\#tbl:tbl-label3\}}\tabularnewline
 EOF
 assert_contains <<EOF
-\undef\pandoctableshortcapt
+\let\pandoctableshortcapt\relax
 EOF
 
 # Test 4
@@ -59,7 +59,7 @@ an \textbf{overriding} short-caption. This is the expected usage.
 \{\#tbl:tbl-label4\}}\tabularnewline
 EOF
 assert_contains <<EOF
-\undef\pandoctableshortcapt
+\let\pandoctableshortcapt\relax
 EOF
 
 # Test 5
@@ -101,5 +101,5 @@ assert_contains <<EOF
 \{\#tbl:tbl-label9\}}\tabularnewline
 EOF
 assert_contains <<EOF
-\undef\pandoctableshortcapt
+\let\pandoctableshortcapt\relax
 EOF

--- a/table-short-captions/test-table-short-captions.sh
+++ b/table-short-captions/test-table-short-captions.sh
@@ -4,9 +4,10 @@ latex_result="$(cat -)"
 
 assert_contains ()
 {
-    printf '%s' "$latex_result" | grep -qF "$1" -
+    content="$(cat -)"
+    printf '%s' "$latex_result" | grep -qF "$content" -
     if [ $? -ne 0 ]; then
-        printf 'Output does not contain `%s`.\n' "$1" >&2
+        printf 'Output does not contain `%s`.\n' "$content" >&2
         exit 1
     fi
 }


### PR DESCRIPTION
Support for Pandoc 2.10 is not working, and all the tests are broken too, they do not check anything.

This PR fixes Pandoc 2.10 support, and also fixes the tests to ensure they do run (and updates them to the changes introduced by  7a49118).

Commit 6e1b2cc introduced support for Pandoc 2.10 but it doesn't work because it treats the new `Table.caption.long` object as the pre 2.10 `Table.caption` object, but they are completely different lists. `Table.caption.long` is a list of `Blocks`, where each block has a `content` key which is a `List` of inlines (or it should be, a test would be needed for more complex captions?). The pre 2.10 `Table.caption` is a `List` of inlines, so they cannot share the same code to be manipulated.

This PR fixes it by just splitting the code into two different functions. They do follow the same structure, but it is better to keep them separated, otherwise it would require too many ifs, or code that is not clear.

For pre 2.10 `Table.caption` just keep the code as it is. For the new `Table.caption.long`, ensure the outer list of `Blocks` is taken into account when searching for the inline `Span` with the short caption.

Now all test do run and all pass, with pre and post Pandoc 2.10 (`nix-run-version` is a helper that allows  me to use [nixpkgs](https://github.com/NixOS/nixpkgs) releases to run different versions of a command)

Before this PR (well, not really, this PR also fixes the tests to see them failing. Before the last commit fixing 2.10 support):

``` shell
nix-run-version 19.09 pandoc make && echo "no errors"
pandoc 2.7.3
Compiled with pandoc-types 1.17.6, texmath 0.11.2.2, skylighting 0.8.2
no errors

$ nix-run-version 20.09 pandoc make && echo "no errors"
pandoc 2.10.1
Compiled with pandoc-types 1.21, texmath 0.12.0.2, skylighting 0.8.5
Output does not contain `\def\pandoctableshortcapt{}  % .unlisted`.
make: *** [test] Error 1
```

With this PR:

``` shell
$ nix-run-version 19.09 pandoc make && echo "no errors"
pandoc 2.7.3
Compiled with pandoc-types 1.17.6, texmath 0.11.2.2, skylighting 0.8.2
no errors

$ nix-run-version 20.09 pandoc make && echo "no errors"
pandoc 2.10.1
Compiled with pandoc-types 1.21, texmath 0.12.0.2, skylighting 0.8.5
no errors

$ nix-run-version unstable pandoc make && echo "no errors"
pandoc 2.11.2
Compiled with pandoc-types 1.22, texmath 0.12.0.3, skylighting 0.10.0.3,
citeproc 0.2, ipynb 0.1.0.1
no errors
```