### PR TITLE
Provides not-in-format filter

### DIFF
--- a/not-in-format/LICENSE
+++ b/not-in-format/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Julien Dutant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/not-in-format/Makefile
+++ b/not-in-format/Makefile
@@ -1,0 +1,19 @@
+DIFF ?= diff --strip-trailing-cr -u
+
+.PHONY: test
+
+test: test_html test_latex
+
+test_html: sample.md expected.html not-in-format.lua
+	@pandoc --lua-filter not-in-format.lua --to=html $< \
+		| $(DIFF) expected.html -
+
+test_latex: sample.md expected.tex not-in-format.lua
+	@pandoc --lua-filter not-in-format.lua --to=latex $< \
+		| $(DIFF) expected.tex -
+
+expected.html: sample.md not-in-format.lua
+	pandoc --lua-filter not-in-format.lua --output $@ $<
+
+expected.tex: sample.md not-in-format.lua
+	pandoc --lua-filter not-in-format.lua --output $@ $<

--- a/not-in-format/README.md
+++ b/not-in-format/README.md
@@ -1,0 +1,77 @@
+---
+title: "Not-in-format - Keep document parts out of selected output formats"
+author: "Julien Dutant"
+---
+
+Not-in-format
+=======
+
+Keeps parts of a document out of selected output formats.
+
+v1.0. Copyright: © 2021 Julien Dutant <julien.dutant@kcl.ac.uk>
+License:  MIT - see LICENSE file for details.
+
+Usage
+-----
+
+This Lua filter for Pandoc that keeps parts of a document out of selected outputs formats.
+
+*Use case*. Sometimes a bit of markdown will convert well through Pandoc to some formats not others. Say, you have a table that is reasonably well converted to html and docx, but you want more control on the LaTeX output. This filter allows you to:
+
+* Enter the desired LaTeX table output as a [fenced block with a raw attribute](https://pandoc.org/MANUAL.html#extension-raw_attribute).
+* Mark up the markdown table so that it is output only in formats other than LaTeX.
+
+*Usage*. Mark up the part you want to keep out of some output format(s) as a native Div with the attributes `not-in-format` and the names of the format(s) in question:
+
+```markdown
+::: {.not-in-format .latex .beamer}
+
+---------------------------
+This table   is not kept
+----------- ----------------
+in formats    latex, beamer
+----------------------------
+
+:::
+```
+
+Use format names for [Pandoc's list of output formats](https://pandoc.org/MANUAL.html#option--to), which you can print out by running ```pandoc --list-output-formats```.
+
+You would normally provide a raw equivalent for the part in question in the format(s) in question, using Pandoc's [fenced blocks with a raw attribute](https://pandoc.org/MANUAL.html#extension-raw_attribute):
+
+```markdown
+::: {.not-in-format .latex .beamer}
+
+---------------------------
+This table   is not kept
+----------- ----------------
+in formats    latex, beamer
+----------------------------
+
+:::
+
+~~~{=latex}
+
+begin{tabular}{|c|c|}
+\toprule
+This table & is not kept \\ \addlinespace
+\midrule
+\endhead
+in formats & latex, beamer \\ \addlinespace
+\bottomrule
+\end{tabluar}
+
+~~~
+```
+
+A fenced block with a raw attribute can only have one attribute, so you need one for each format for which the markdown is left out. But Pandoc will output the raw block in equivalent formats: a `latex` block will be output in `latex` and `beamer`, a `html5` block in `html` and `epub3` and so on. See [Pandoc's manual](https://pandoc.org/MANUAL.html#extension-raw_attribute).
+
+Installation
+------------
+
+Copy `not-in-format.lua` in your document folder or in your pandoc file.
+
+Contributing
+------------
+
+PRs welcome.

--- a/not-in-format/README.md
+++ b/not-in-format/README.md
@@ -1,5 +1,6 @@
 ---
-title: "Not-in-format - Keep document parts out of selected output formats"
+title: "Not-in-format - Keep document parts out of selected output
+  formats"
 author: "Julien Dutant"
 ---
 
@@ -16,12 +17,19 @@ Usage
 
 This Lua filter for Pandoc that keeps parts of a document out of selected outputs formats.
 
-*Use case*. Sometimes a bit of markdown will convert well through Pandoc to some formats not others. Say, you have a table that is reasonably well converted to html and docx, but you want more control on the LaTeX output. This filter allows you to:
+*Use case*. Sometimes a bit of markdown will convert well through Pandoc
+to some formats not others. Say, you have a table that is reasonably
+well converted to html and docx, but you want more control on the
+LaTeX output. This filter allows you to:
 
-* Enter the desired LaTeX table output as a [fenced block with a raw attribute](https://pandoc.org/MANUAL.html#extension-raw_attribute).
-* Mark up the markdown table so that it is output only in formats other than LaTeX.
+* Enter the desired LaTeX table output as a [fenced block with a raw
+  attribute](https://pandoc.org/MANUAL.html#extension-raw_attribute).
+* Mark up the markdown table so that it is output only in formats other
+  than LaTeX.
 
-*Usage*. Mark up the part you want to keep out of some output format(s) as a native Div with the attributes `not-in-format` and the names of the format(s) in question:
+*Usage*. Mark up the part you want to keep out of some output format(s)
+as a native Div with the attributes `not-in-format` and the names of the
+format(s) in question:
 
 ```markdown
 ::: {.not-in-format .latex .beamer}
@@ -37,7 +45,9 @@ in formats    latex, beamer
 
 Use format names for [Pandoc's list of output formats](https://pandoc.org/MANUAL.html#option--to), which you can print out by running ```pandoc --list-output-formats```.
 
-You would normally provide a raw equivalent for the part in question in the format(s) in question, using Pandoc's [fenced blocks with a raw attribute](https://pandoc.org/MANUAL.html#extension-raw_attribute):
+You would normally provide a raw equivalent for the part in question in
+the format(s) in question, using Pandoc's [fenced blocks with a raw
+attribute](https://pandoc.org/MANUAL.html#extension-raw_attribute):
 
 ```markdown
 ::: {.not-in-format .latex .beamer}
@@ -64,12 +74,17 @@ in formats & latex, beamer \\ \addlinespace
 ~~~
 ```
 
-A fenced block with a raw attribute can only have one attribute, so you need one for each format for which the markdown is left out. But Pandoc will output the raw block in equivalent formats: a `latex` block will be output in `latex` and `beamer`, a `html5` block in `html` and `epub3` and so on. See [Pandoc's manual](https://pandoc.org/MANUAL.html#extension-raw_attribute).
+A fenced block with a raw attribute can only have one attribute, so you
+need one for each format for which the markdown is left out. But Pandoc
+will output the raw block in equivalent formats: a `latex` block will
+be output in `latex` and `beamer`, a `html5` block in `html` and `epub3`
+and so on. See [Pandoc's manual](https://pandoc.org/MANUAL.html#extension-raw_attribute).
 
 Installation
 ------------
 
-Copy `not-in-format.lua` in your document folder or in your pandoc file.
+Copy `not-in-format.lua` in your document folder or in your pandoc data
+dir path.
 
 Contributing
 ------------

--- a/not-in-format/expected.html
+++ b/not-in-format/expected.html
@@ -1,0 +1,21 @@
+<p>The table below exists in two versions. The LaTeX version will be used in <code>latex</code> and <code>beamer</code> and the markdown version in all other output formats.</p>
+<div class="not-in-format latex beamer">
+<table style="width:40%;">
+<colgroup>
+<col style="width: 16%" />
+<col style="width: 23%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th style="text-align: left;">This table</th>
+<th style="text-align: center;">is not kept</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: left;">in formats</td>
+<td style="text-align: center;">latex, beamer</td>
+</tr>
+</tbody>
+</table>
+</div>

--- a/not-in-format/expected.tex
+++ b/not-in-format/expected.tex
@@ -1,0 +1,12 @@
+The table below exists in two versions. The LaTeX version will be used
+in \texttt{latex} and \texttt{beamer} and the markdown version in all
+other output formats.
+
+begin{tabular}{|c|c|}
+\toprule
+This table & is used \\ \addlinespace
+\midrule
+\endhead
+in formats & latex, beamer \\ \addlinespace
+\bottomrule
+\end{tabluar}

--- a/not-in-format/not-in-format.lua
+++ b/not-in-format/not-in-format.lua
@@ -1,0 +1,35 @@
+--- not-in-format - keep document parts out of selected output formats.
+--
+-- This Lua filter for Pandoc that keeps parts of a document out of
+-- selected outputs formats.
+--
+-- v1.0
+--
+-- @author Julien Dutant <julien.dutant@kcl.ac.uk>
+-- @copyright 2021 Julien Dutant
+-- @license MIT - see LICENSE file for details.
+--
+
+--- Test whether the target format is in a given list
+-- @param formats list of formats to be matched
+-- @return true if match, false otherwise
+local function format_matches(formats)
+  for _,format in pairs(formats) do
+    if FORMAT:match(format) then
+      return true
+    end
+  end
+  return false
+end
+
+--- Main Div filter
+-- Removes Divs tagged with `not-in-format` if the
+-- output format matches one of the Div's attributes
+function Div(element)
+  if element.classes:includes('not-in-format') and
+    format_matches(element.classes) then
+      return {}
+    else
+      return element
+    end
+end

--- a/not-in-format/not-in-format.lua
+++ b/not-in-format/not-in-format.lua
@@ -24,7 +24,7 @@ function Div(element)
   if element.classes:includes('not-in-format') and
     element.classes:find_if(function (x) return FORMAT:match(x) end) then
       return {}
-    else
-      return element
-    end
+
+  -- else the function returns `nil` and Pandoc leaves the element as is
+
 end

--- a/not-in-format/not-in-format.lua
+++ b/not-in-format/not-in-format.lua
@@ -24,6 +24,7 @@ function Div(element)
   if element.classes:includes('not-in-format') and
     element.classes:find_if(function (x) return FORMAT:match(x) end) then
       return {}
+  end
 
   -- else the function returns `nil` and Pandoc leaves the element as is
 

--- a/not-in-format/not-in-format.lua
+++ b/not-in-format/not-in-format.lua
@@ -1,14 +1,12 @@
---- not-in-format - keep document parts out of selected output formats.
+--- # not-in-format - keep document parts out of selected output formats.
 --
 -- This Lua filter for Pandoc that keeps parts of a document out of
 -- selected outputs formats.
 --
--- v1.0
---
 -- @author Julien Dutant <julien.dutant@kcl.ac.uk>
 -- @copyright 2021 Julien Dutant
 -- @license MIT - see LICENSE file for details.
---
+-- @release 1.0
 
 --- Test whether the target format is in a given list
 -- @param formats list of formats to be matched
@@ -22,9 +20,12 @@ local function format_matches(formats)
   return false
 end
 
---- Main Div filter
+--- Main Div filter.
 -- Removes Divs tagged with `not-in-format` if the
 -- output format matches one of the Div's attributes
+-- @param element a Div element
+-- @return an empty block if the Div classes include `not-in-format` and
+--  and the target format
 function Div(element)
   if element.classes:includes('not-in-format') and
     format_matches(element.classes) then

--- a/not-in-format/not-in-format.lua
+++ b/not-in-format/not-in-format.lua
@@ -3,32 +3,26 @@
 -- This Lua filter for Pandoc that keeps parts of a document out of
 -- selected outputs formats.
 --
--- @author Julien Dutant <julien.dutant@kcl.ac.uk>
--- @copyright 2021 Julien Dutant
+-- @author Julien Dutant <julien.dutant@kcl.ac.uk>, Albert Krewinkel
+-- @copyright 2021 Julien Dutant, Albert Krewinkel
 -- @license MIT - see LICENSE file for details.
 -- @release 1.0
-
---- Test whether the target format is in a given list
--- @param formats list of formats to be matched
--- @return true if match, false otherwise
-local function format_matches(formats)
-  for _,format in pairs(formats) do
-    if FORMAT:match(format) then
-      return true
-    end
-  end
-  return false
-end
 
 --- Main Div filter.
 -- Removes Divs tagged with `not-in-format` if the
 -- output format matches one of the Div's attributes
 -- @param element a Div element
--- @return an empty block if the Div classes include `not-in-format` and
---  and the target format
+-- @return an empty block if the Div classes include `not-in-format`
+-- and the target format
 function Div(element)
+
+  -- the find_if method returns the first value x in the list
+  -- element.classes for which FORMAT:match(x) evaluates as true,
+  -- and nil otherwise. Within the if clause that value evaluates
+  -- as true and nil evaluates as false.
+
   if element.classes:includes('not-in-format') and
-    format_matches(element.classes) then
+    element.classes:find_if(function (x) return FORMAT:match(x) end) then
       return {}
     else
       return element

--- a/not-in-format/sample.md
+++ b/not-in-format/sample.md
@@ -1,0 +1,24 @@
+The table below exists in two versions. The LaTeX version will be used in `latex` and `beamer` and the markdown version in all other output formats.
+
+::: {.not-in-format .latex .beamer}
+
+---------------------------
+This table   is not kept
+----------- ----------------
+in formats    latex, beamer
+----------------------------
+
+:::
+
+~~~{=latex}
+
+begin{tabular}{|c|c|}
+\toprule
+This table & is used \\ \addlinespace
+\midrule
+\endhead
+in formats & latex, beamer \\ \addlinespace
+\bottomrule
+\end{tabluar}
+
+~~~


### PR DESCRIPTION
A simple filter to keep parts of documents out of selected formats. Useful if you want to provide Raw code for some but not all output formats, e.g., if you have a markdown table that works well in formats other than LaTeX and you want to provide alternative raw code for LaTeX output only. 