### PR TITLE
multiple-bibliographies: Set the div attributes and classes according to the attributes of the cs:bibliography element

### DIFF
--- a/multiple-bibliographies/expected.native
+++ b/multiple-bibliographies/expected.native
@@ -1,13 +1,13 @@
 Pandoc (Meta {unMeta = fromList [("bibliography_recommended_reading",MetaInlines [Str "secondary.bib"]),("bibliography_sources",MetaInlines [Str "primary.bib"]),("nocite",MetaInlines [Cite [Citation {citationId = "Knu86", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 1, citationHash = 0}] [Str "@Knu86"],Str ",",Space,Cite [Citation {citationId = "Bae", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 2, citationHash = 0}] [Str "@Bae"]]),("title",MetaInlines [Str "Multiple",Space,Str "Bibliographies",Space,Str "Demo"])]})
 [Para [Cite [Citation {citationId = "Nie72", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 3, citationHash = 0}] [Str "Nietzsche",Space,Str "(1872)"],Str ",",Space,Cite [Citation {citationId = "Bel", citationPrefix = [], citationSuffix = [], citationMode = AuthorInText, citationNoteNum = 4, citationHash = 0}] [Str "Bellori",Space,Str "(1672)"]]
 ,Header 1 ("references",[],[]) [Str "References"]
-,Div ("refs_sources",["csl-bib-body"],[])
+,Div ("refs_sources",["references","csl-bib-body","hanging-indent"],[])
  [Div ("ref-Bel",["csl-entry"],[])
   [Para [Str "Bellori.",Space,Str "1672.",Space,Emph [Str "Le",Space,Str "Vite",Space,Str "de\8217",Space,Str "Pittori,",Space,Str "Scultori",Space,Str "e",Space,Str "Architetti",Space,Str "Moderni"],Str "."]]
  ,Div ("ref-Nie72",["csl-entry"],[])
   [Para [Str "Nietzsche,",Space,Str "Friedrich.",Space,Str "1872.",Space,Emph [Str "Die",Space,Str "Geburt",Space,Str "Der",Space,Str "Trag\246die",Space,Str "Aus",Space,Str "Dem",Space,Str "Geiste",Space,Str "Der",Space,Str "Musik"],Str "."]]]
 ,Header 1 ("recommended-reading",[],[]) [Str "Recommended",Space,Str "Reading"]
-,Div ("refs_recommended_reading",["csl-bib-body"],[])
+,Div ("refs_recommended_reading",["references","csl-bib-body","hanging-indent"],[])
  [Div ("ref-Bae",["csl-entry"],[])
   [Para [Str "B\228tschmann,",Space,Str "Oskar.",Space,Str "1985.",Space,Emph [Str "Pygmalion",Space,Str "Als",Space,Str "Betrachter"],Str "."]]
  ,Div ("ref-Knu86",["csl-entry"],[])

--- a/multiple-bibliographies/multiple-bibliographies.lua
+++ b/multiple-bibliographies/multiple-bibliographies.lua
@@ -28,6 +28,10 @@ local doc_meta = pandoc.Meta{}
 --- Div used by pandoc-citeproc to insert the bibliography.
 local refs_div = pandoc.Div({}, pandoc.Attr('refs'))
 
+-- Div filled by pandoc-citeproc with properties set according to
+-- the output format and the attributes of cs:bibliography
+local refs_div_with_properties
+
 local supports_quiet_flag = (function ()
   -- We use pandoc instead of pandoc-citeproc starting with pandoc 2.11
   if PANDOC_VERSION >= "2.11" then
@@ -76,8 +80,8 @@ local function resolve_doc_citations (doc)
   -- resolve all citations
   -- doc = run_json_filter(doc, 'pandoc-citeproc')
   doc = run_citeproc(doc)
-  -- remove catch-all bibliography
-  table.remove(doc.blocks)
+  -- remove catch-all bibliography and keep it for future use
+  refs_div_with_properties = table.remove(doc.blocks)
   -- restore bibliography to original value
   doc.meta.bibliography = orig_bib
   return doc
@@ -118,11 +122,9 @@ local function create_topic_bibliography (div)
   -- First block of the result contains the dummy paragraph, second is
   -- the refs Div filled by pandoc-citeproc.
   div.content = res.blocks[2].content
-  -- ensure that the div has class 'csl-bib-body'. The LaTeX writer expects it
-  -- as a marker for reference divs.
-  div.classes = div.classes:includes 'csl-bib-body'
-    and div.classes
-    or div.classes .. {'csl-bib-body'}
+  -- Set the classes and attributes as pandoc-citeproc did it on refs_div
+  div.classes = refs_div_with_properties.classes
+  div.attributes = refs_div_with_properties.attributes
   return div
 end
 


### PR DESCRIPTION
In the CSL stylesheet, the element `cs:bibliography` may carry various attributes determining the rendering of the bibliography that citeproc converts into classes and attributes for the references div. As the filter simply puts the partial bibliographies created by citeproc into the custom divs, these classes and attributes are not set (excepted `csl-bib-body`). I propose to store the div created by citeproc in order to copy its classes and attributes to the custom divs. 

It has the side effect that all classes and attributes manually set by the user for the corresponding divs will be ignored. I think it more as a feature than as a drawback, since one probably should not do this anyway, but modify the CSL file instead. However, if the possibility of overriding the CSL file is desired (to use different layouts across the document?), the proposed modification can be expanded so that each class or attribute of `refs_div_with_properties` is added to `div` only if it is not already set.