### PR TITLE
Include files filter updates

### DIFF
--- a/include-files/Makefile
+++ b/include-files/Makefile
@@ -10,6 +10,6 @@ expected.native: sample.md file-a.md file-b.md file-c.md include-files.lua
 	pandoc --lua-filter=include-files.lua --output $@ $<
 
 expected-auto.native: sample.md file-a.md file-b.md file-c.md include-files.lua
-	pandoc --lua-filter=include-files.lua --output $@ $<
+	pandoc --lua-filter=include-files.lua -M include-auto --output $@ $<
 
 .PHONY: test

--- a/include-files/README.md
+++ b/include-files/README.md
@@ -62,10 +62,13 @@ Only plain-text formats are accepted.
 ### Recursive transclusion
 
 Included files can in turn include other files. Note that all
-filenames must be relative to the directory from which pandoc is
-run. I.e., if a file `a/b.md` is included in the main document,
-and another file `a/b/c.md` should be included, the full relative
-path must be used. Writing `b/c.md` in `a/b.md` would _not_ work.
+filenames must be relative to the directory from which they are
+included. I.e., if a file `a/b.md` is included in the main
+document, and another file `a/b/c.md` should be included from
+`a/b.md`, then the relative path from `a/b.md` must be used, in
+this case `b/c.md`. The full relative path will be automatically
+generated in the final document. The same goes for image paths and
+codeblock file paths using the `include-code-files` filter.
 
 ## Example
 

--- a/include-files/expected-auto.native
+++ b/include-files/expected-auto.native
@@ -16,6 +16,13 @@
 ,Para [Str "This",Space,Str "is",Space,Code ("",[],[]) "file-a.md",Str "."]
 ,Header 3 ("title-of-file-a",[],[]) [Str "Title",Space,Str "of",Space,Str "file-a"]
 ,Para [Str "This",Space,Str "is",Space,Code ("",[],[]) "file-a.md",Str "."]
+,Header 1 ("subdirectories",[],[]) [Str "Subdirectories"]
+,Header 2 ("image-include",[],[]) [Str "Image",Space,Str "include"]
+,Para [Str "Image",Space,Str "relative",Space,Str "path",Space,Str "will",Space,Str "be",Space,Str "updated."]
+,Para [Image ("",[],[]) [Str "Image",Space,Str "title"] ("subdir/someimage.png","fig:")]
+,Header 2 ("source-include",[],[]) [Str "Source",Space,Str "include"]
+,Para [Str "File",Space,Str "inclusion",Space,Str "codeblocks",Space,Str "for",Space,Str "use",Space,Str "with",Space,Str "include-code-files",Space,Str "will",Space,Str "be",SoftBreak,Str "updated",Space,Str "too."]
+,CodeBlock ("",["c"],[("include","subdir/somecode.c")]) ""
 ,Header 1 ("appendix",[],[]) [Str "Appendix"]
 ,Para [Str "More",Space,Str "info",Space,Str "goes",Space,Str "here."]
 ,Header 2 ("questionaire",[],[]) [Str "Questionaire"]

--- a/include-files/expected.native
+++ b/include-files/expected.native
@@ -16,6 +16,13 @@
 ,Para [Str "This",Space,Str "is",Space,Code ("",[],[]) "file-a.md",Str "."]
 ,Header 2 ("title-of-file-a",[],[]) [Str "Title",Space,Str "of",Space,Str "file-a"]
 ,Para [Str "This",Space,Str "is",Space,Code ("",[],[]) "file-a.md",Str "."]
+,Header 1 ("subdirectories",[],[]) [Str "Subdirectories"]
+,Header 1 ("image-include",[],[]) [Str "Image",Space,Str "include"]
+,Para [Str "Image",Space,Str "relative",Space,Str "path",Space,Str "will",Space,Str "be",Space,Str "updated."]
+,Para [Image ("",[],[]) [Str "Image",Space,Str "title"] ("subdir/someimage.png","fig:")]
+,Header 1 ("source-include",[],[]) [Str "Source",Space,Str "include"]
+,Para [Str "File",Space,Str "inclusion",Space,Str "codeblocks",Space,Str "for",Space,Str "use",Space,Str "with",Space,Str "include-code-files",Space,Str "will",Space,Str "be",SoftBreak,Str "updated",Space,Str "too."]
+,CodeBlock ("",["c"],[("include","subdir/somecode.c")]) ""
 ,Header 1 ("appendix",[],[]) [Str "Appendix"]
 ,Para [Str "More",Space,Str "info",Space,Str "goes",Space,Str "here."]
 ,Header 2 ("questionaire",[],[]) [Str "Questionaire"]

--- a/include-files/include-files.lua
+++ b/include-files/include-files.lua
@@ -40,6 +40,14 @@ local function update_contents(blocks, shift_by, include_path)
         image.src = path.normalize(path.join({include_path, image.src}))
       end
       return image
+    end,
+    -- Update path for include-code-files.lua filter style CodeBlocks
+    CodeBlock = function (cb)
+      if cb.attributes.include and path.is_relative(cb.attributes.include) then
+        cb.attributes.include =
+          path.normalize(path.join({include_path, cb.attributes.include}))
+        end
+      return cb
     end
   }
 

--- a/include-files/include-files.lua
+++ b/include-files/include-files.lua
@@ -25,7 +25,7 @@ function update_last_level(header)
 end
 
 --- Update contents of included file
-local function update_contents(blocks, shift_by)
+local function update_contents(blocks, shift_by, include_path)
   local update_contents_filter = {
     -- Shift headings in block list by given number
     Header = function (header)
@@ -37,7 +37,7 @@ local function update_contents(blocks, shift_by)
     -- If image paths are relative then prepend include file path
     Image = function (image)
       if path.is_relative(image.src) then
-        image.src = path.join({system.get_working_directory(), image.src})
+        image.src = path.normalize(path.join({include_path, image.src}))
       end
       return image
     end
@@ -92,12 +92,8 @@ function transclude (cb)
             end).content
         --- reset to level before recursion
         last_heading_level = buffer_last_heading_level
-        blocks:extend(
-          system.with_working_directory(
-            path.directory(line),
-            function ()
-              return update_contents(contents, shift_heading_level_by)
-            end))
+        blocks:extend(update_contents(contents, shift_heading_level_by,
+                                      path.directory(line)))
         fh:close()
       end
     end

--- a/include-files/sample.md
+++ b/include-files/sample.md
@@ -28,6 +28,15 @@ file-d.org
 file-f.md
 ```
 
+# Subdirectories
+
+``` {.include}
+// file-g.md includes an image and source code. The relative
+// path used in file-g.md will be prefixed with subdir in the
+// final document.
+subdir/file-g.md
+```
+
 # Appendix
 
 More info goes here.

--- a/include-files/subdir/file-g.md
+++ b/include-files/subdir/file-g.md
@@ -1,0 +1,14 @@
+# Image include
+
+Image relative path will be updated.
+
+![Image title](someimage.png)
+
+# Source include
+
+File inclusion codeblocks for use with include-code-files will be
+updated too.
+
+```{.c include=somecode.c}
+```
+


### PR DESCRIPTION
This patchset keeps the paths to images relative and also improves the usage in combination with the include-code-files.lua filter