### PR TITLE
First-line-indent: fix bug with pre-existing header-includes

### DIFF
--- a/first-line-indent/first-line-indent.lua
+++ b/first-line-indent/first-line-indent.lua
@@ -82,10 +82,10 @@ local header_code = {
 -- @return meta the modified metadata block
 local function add_header_includes(meta, blocks)
 
-  local header_includes = pandoc.List(blocks)
+  local header_includes = pandoc.MetaList( { pandoc.MetaBlocks(blocks) })
 
   -- add any exisiting meta['header-includes']
-  -- it could be a MetaList or a single String
+  -- it can be MetaInlines, MetaBlocks or MetaList
   if meta['header-includes'] then
     if meta['header-includes'].t == 'MetaList' then
       header_includes:extend(meta['header-includes'])
@@ -94,7 +94,7 @@ local function add_header_includes(meta, blocks)
     end
   end
 
-  meta['header-includes'] = pandoc.MetaBlocks(header_includes)
+  meta['header-includes'] = header_includes
 
   return meta
 


### PR DESCRIPTION
The first-line-indent filter crashed when the original document had header-includes already. This is now fixed, tested for all types of header-includes (MetaInlines, MetaBlocks and MetaList).