### PR TITLE
revealjs_codeblock: Enable Line Number Offset (startFrom)

### DIFF
--- a/revealjs-codeblock/Makefile
+++ b/revealjs-codeblock/Makefile
@@ -2,7 +2,7 @@ DIFF ?= diff --strip-trailing-cr -u
 PANDOC ?= pandoc
 
 test:
-	@$(PANDOC) --lua-filter=revealjs-codeblock.lua sample.md -t revealjs | \
+	@$(PANDOC) --lua-filter=revealjs-codeblock.lua sample.md -t revealjs --wrap none | \
 		$(DIFF) expected.html -
 
 .PHONY: test

--- a/revealjs-codeblock/README.md
+++ b/revealjs-codeblock/README.md
@@ -12,11 +12,14 @@ The filter passes the code block attributes to reveal.js. This enables
 the following reveal.js features:
 
 - [Line Numbers &
-  Highlights](https://github.com/hakimel/reveal.js/tree/master/plugin/highlight)
-  and [Step-by-step
-  Highlights](https://revealjs.com/code/#step-by-step-highlights) via
-  the `data-line-numbers` attribute. (`.numerLines` and
+  Highlights](https://revealjs.com/code/#line-numbers-%26-highlights)
+  via the `data-line-numbers` attribute. (`.numerLines` and
   `.number-lines` classes are converted for compatibility.)
+- [Line Number
+  Offset](https://revealjs.com/code/#line-number-offset-4.2.0) (via
+  `data-ln-start-from` and `startFrom` attributes)
+- [Step-by-step
+  Highlights](https://revealjs.com/code/#step-by-step-highlights)
 - [Auto-Animation](https://revealjs.com/auto-animate/#example%3A-animating-between-code-blocks)
   of code blocks with line numbers and a `data-id`. (The slide
   headings need the `data-auto-animate` attribute.)
@@ -32,7 +35,7 @@ two additional variables:
   [comes](https://github.com/hakimel/reveal.js/tree/master/plugin/highlight)
   with `monokai` (default) and `zenburn`.
 
-```bash
+``` bash
 $ pandoc sample.md -o sample.html -t revealjs -L revealjs-codeblock.lua \
   --template template.html -V highlightjs -V highlightjs-theme:zenburn
 ```

--- a/revealjs-codeblock/expected.html
+++ b/revealjs-codeblock/expected.html
@@ -65,6 +65,11 @@ function SecondExample() {
 </section>
 <section id="test-line-number-offset" class="slide level1">
 <h1>test line number offset</h1>
+<pre ><code class="html" data-line-numbers="" data-ln-start-from="7">&lt;tr&gt;
+  &lt;td&gt;Oranges&lt;/td&gt;
+  &lt;td&gt;$2&lt;/td&gt;
+  &lt;td&gt;18&lt;/td&gt;
+&lt;/tr&gt;</code></pre>
 <pre ><code class="haskell" data-ln-start-from="100" data-line-numbers="">qsort []     = []
 qsort (x:xs) = qsort (filter (&lt; x) xs) ++ [x] ++
                qsort (filter (&gt;= x) xs)</code></pre>

--- a/revealjs-codeblock/expected.html
+++ b/revealjs-codeblock/expected.html
@@ -63,3 +63,9 @@ function SecondExample() {
 <pre id="code"><code >{#code}</code></pre>
 <pre data-id="code-animate"><code >{data-id="code-animate"}</code></pre>
 </section>
+<section id="test-line-number-offset" class="slide level1">
+<h1>test line number offset</h1>
+<pre ><code class="haskell" data-ln-start-from="100" data-line-numbers="">qsort []     = []
+qsort (x:xs) = qsort (filter (&lt; x) xs) ++ [x] ++
+               qsort (filter (&gt;= x) xs)</code></pre>
+</section>

--- a/revealjs-codeblock/revealjs-codeblock.lua
+++ b/revealjs-codeblock/revealjs-codeblock.lua
@@ -59,6 +59,9 @@ function CodeBlock(block)
       attribute_string = string.format('%s="%s"', k, v)
       if is_pre_tag_attribute(k) then
         table.insert(pre_tag_attributes, attribute_string)
+      elseif k == "startFrom" then
+        table.insert(code_tag_attributes,
+                      string.format('data-ln-start-from="%s"', v))
       else
         table.insert(code_tag_attributes, attribute_string)
       end

--- a/revealjs-codeblock/revealjs-codeblock.lua
+++ b/revealjs-codeblock/revealjs-codeblock.lua
@@ -16,7 +16,8 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ]]
 local function is_numberlines_class(class)
-  return class == 'numberLines' or class == 'number-lines'
+  class = class:lower()
+  return class == 'numberlines' or class == 'number-lines'
 end
 
 local function is_pre_tag_attribute(attribute)

--- a/revealjs-codeblock/sample.md
+++ b/revealjs-codeblock/sample.md
@@ -91,3 +91,11 @@ function SecondExample() {
 ``` {data-id="code-animate"}
 {data-id="code-animate"}
 ```
+
+# test line number offset
+
+``` {.haskell .numberLines startFrom="100"}
+qsort []     = []
+qsort (x:xs) = qsort (filter (< x) xs) ++ [x] ++
+               qsort (filter (>= x) xs)
+```

--- a/revealjs-codeblock/sample.md
+++ b/revealjs-codeblock/sample.md
@@ -94,6 +94,14 @@ function SecondExample() {
 
 # test line number offset
 
+``` {.html data-line-numbers="" data-ln-start-from="7"}
+<tr>
+  <td>Oranges</td>
+  <td>$2</td>
+  <td>18</td>
+</tr>
+```
+
 ``` {.haskell .numberLines startFrom="100"}
 qsort []     = []
 qsort (x:xs) = qsort (filter (< x) xs) ++ [x] ++

--- a/revealjs-codeblock/sample.md
+++ b/revealjs-codeblock/sample.md
@@ -1,5 +1,4 @@
-Pretty Code {#pretty-code data-auto-animate=""}
-===========
+# Pretty Code {#pretty-code data-auto-animate=""}
 
 ``` {.jsx .numberLines data-id="code-animation"}
 import React, { useState } from 'react';
@@ -15,8 +14,7 @@ function Example() {
 
 Example courtesy of [reveal.js](https://revealjs.com/#/4).
 
-Even Prettier Animations {#even-prettier-animations data-auto-animate=""}
-========================
+# Even Prettier Animations {#even-prettier-animations data-auto-animate=""}
 
 ``` {.jsx data-line-numbers="|4,8-11|17|22-24" data-id="code-animation"}
 import React, { useState } from 'react';
@@ -48,16 +46,15 @@ function SecondExample() {
 }
 ```
 
-test line number classes
-========================
+# test line number classes
 
     unnumbered
 
-``` {.numberLines}
+``` numberLines
 {.numberLines}
 ```
 
-``` {.number-lines}
+``` number-lines
 {.number-lines}
 ```
 
@@ -65,8 +62,7 @@ test line number classes
 {.numberLines .number-lines}
 ```
 
-test data-line-numbers attribute
-================================
+# test data-line-numbers attribute
 
 ``` {data-line-numbers="1"}
 {data-line-numbers="1"}
@@ -76,8 +72,7 @@ test data-line-numbers attribute
 {.numberLines data-line-numbers="1"}
 ```
 
-test code tag attributes
-========================
+# test code tag attributes
 
 ``` {.html .another-class}
 {.html .another-class}
@@ -87,8 +82,7 @@ test code tag attributes
 {data-trim="" some-other-attribute="" style="border: 1px solid yellow;"}
 ```
 
-test pre tag attributes
-=======================
+# test pre tag attributes
 
 ``` {#code}
 {#code}

--- a/revealjs-codeblock/template.html
+++ b/revealjs-codeblock/template.html
@@ -19,6 +19,9 @@ $endif$
   <link rel="stylesheet" href="$revealjs-url$/dist/reset.css">
   <link rel="stylesheet" href="$revealjs-url$/dist/reveal.css">
   <style>
+    .reveal .sourceCode {  /* see #7635 */
+      overflow: visible;
+    }
     $styles.html()$
   </style>
 $if(theme)$
@@ -59,6 +62,9 @@ $endif$
 $for(author)$
   <p class="author">$author$</p>
 $endfor$
+$for(institute)$
+  <p class="institute">$institute$</p>
+$endfor$
 $if(date)$
   <p class="date">$date$</p>
 $endif$
@@ -66,7 +72,12 @@ $endif$
 $endif$
 $if(toc)$
 <section id="$idprefix$TOC">
+<nav role="doc-toc"> 
+$if(toc-title)$
+<h2 id="$idprefix$toc-title">$toc-title$</h2>
+$endif$
 $table-of-contents$
+</nav>
 </section>
 $endif$
 
@@ -76,7 +87,7 @@ $body$
 
   <script src="$revealjs-url$/dist/reveal.js"></script>
 
-  // reveal.js plugins
+  <!-- reveal.js plugins -->
   <script src="$revealjs-url$/plugin/notes/notes.js"></script>
   <script src="$revealjs-url$/plugin/search/search.js"></script>
   <script src="$revealjs-url$/plugin/zoom/zoom.js"></script>
@@ -92,244 +103,198 @@ $endif$
       // Full list of configuration options available at:
       // https://revealjs.com/config/
       Reveal.initialize({
-$if(controls)$
         // Display controls in the bottom right corner
         controls: $controls$,
-$endif$
-$if(controlsTutorial)$
+
         // Help the user learn the controls by providing hints, for example by
         // bouncing the down arrow when they first encounter a vertical slide
         controlsTutorial: $controlsTutorial$,
-$endif$
-$if(controlsLayout)$
+
         // Determines where controls appear, "edges" or "bottom-right"
-        controlsLayout: $controlsLayout$,
-$endif$
-$if(controlsBackArrows)$
+        controlsLayout: '$controlsLayout$',
+
         // Visibility rule for backwards navigation arrows; "faded", "hidden"
         // or "visible"
-        controlsBackArrows: $controlsBackArrows$,
-$endif$
-$if(progress)$
+        controlsBackArrows: '$controlsBackArrows$',
+
         // Display a presentation progress bar
         progress: $progress$,
-$endif$
-$if(slideNumber)$
+
         // Display the page number of the current slide
         slideNumber: $slideNumber$,
-$endif$
-$if(hash)$
+
+        // 'all', 'print', or 'speaker'
+        showSlideNumber: '$showSlideNumber$',
+
         // Add the current slide number to the URL hash so that reloading the
         // page/copying the URL will return you to the same slide
         hash: $hash$,
-$endif$
+
+        // Start with 1 for the hash rather than 0
+        hashOneBasedIndex: $hashOneBasedIndex$,
+
+        // Flags if we should monitor the hash and change slides accordingly
+        respondToHashChanges: $respondToHashChanges$,
+
         // Push each slide change to the browser history
-$if(history)$
         history: $history$,
-$else$
-        history: true,
-$endif$
-$if(keyboard)$
+
         // Enable keyboard shortcuts for navigation
         keyboard: $keyboard$,
-$endif$
-$if(overview)$
+
         // Enable the slide overview mode
         overview: $overview$,
-$endif$
-$if(center)$
+
+        // Disables the default reveal.js slide layout (scaling and centering)
+        // so that you can use custom CSS layout
+        disableLayout: $disableLayout$,
+
         // Vertical centering of slides
         center: $center$,
-$endif$
-$if(touch)$
+
         // Enables touch navigation on devices with touch input
         touch: $touch$,
-$endif$
-$if(loop)$
+
         // Loop the presentation
         loop: $loop$,
-$endif$
-$if(rtl)$
+
         // Change the presentation direction to be RTL
         rtl: $rtl$,
-$endif$
-$if(navigationMode)$
+
         // see https://revealjs.com/vertical-slides/#navigation-mode
         navigationMode: '$navigationMode$',
-$endif$
-$if(shuffle)$
+
         // Randomizes the order of slides each time the presentation loads
         shuffle: $shuffle$,
-$endif$
-$if(fragments)$
+
         // Turns fragments on and off globally
         fragments: $fragments$,
-$endif$
-$if(fragmentInURL)$
+
         // Flags whether to include the current fragment in the URL,
         // so that reloading brings you to the same fragment position
         fragmentInURL: $fragmentInURL$,
-$endif$
-$if(embedded)$
+
         // Flags if the presentation is running in an embedded mode,
         // i.e. contained within a limited portion of the screen
         embedded: $embedded$,
-$endif$
-$if(help)$
+
         // Flags if we should show a help overlay when the questionmark
         // key is pressed
         help: $help$,
-$endif$
-$if(showNotes)$
+
+        // Flags if it should be possible to pause the presentation (blackout)
+        pause: $pause$,
+
         // Flags if speaker notes should be visible to all viewers
         showNotes: $showNotes$,
-$endif$
-$if(autoPlayMedia)$
-        // Global override for autoplaying embedded media (video/audio/iframe)
-        // - null: Media will only autoplay if data-autoplay is present
-        // - true: All media will autoplay, regardless of individual setting
-        // - false: No media will autoplay, regardless of individual setting
+
+        // Global override for autoplaying embedded media (null/true/false)
         autoPlayMedia: $autoPlayMedia$,
-$endif$
-$if(preloadIframes)$
-        // Global override for preloading lazy-loaded iframes
-        // - null: Iframes with data-src AND data-preload will be loaded when within
-        //   the viewDistance, iframes with only data-src will be loaded when visible
-        // - true: All iframes with data-src will be loaded when within the viewDistance
-        // - false: All iframes with data-src will be loaded only when visible
+
+        // Global override for preloading lazy-loaded iframes (null/true/false)
         preloadIframes: $preloadIframes$,
-$endif$
-$if(autoSlide)$
+
         // Number of milliseconds between automatically proceeding to the
         // next slide, disabled when set to 0, this value can be overwritten
         // by using a data-autoslide attribute on your slides
         autoSlide: $autoSlide$,
-$endif$
-$if(autoSlideStoppable)$
+
         // Stop auto-sliding after user input
         autoSlideStoppable: $autoSlideStoppable$,
-$endif$
-$if(autoSlideMethod)$
+
         // Use this method for navigation when auto-sliding
         autoSlideMethod: $autoSlideMethod$,
-$endif$
-$if(defaultTiming)$
+
         // Specify the average time in seconds that you think you will spend
         // presenting each slide. This is used to show a pacing timer in the
         // speaker view
         defaultTiming: $defaultTiming$,
-$endif$
-$if(totalTime)$
-        // Specify the total time in seconds that is available to
-        // present.  If this is set to a nonzero value, the pacing
-        // timer will work out the time available for each slide,
-        // instead of using the defaultTiming value
-        totalTime: $totalTime$,
-$endif$
-$if(minimumTimePerSlide)$
-        // Specify the minimum amount of time you want to allot to
-        // each slide, if using the totalTime calculation method.  If
-        // the automated time allocation causes slide pacing to fall
-        // below this threshold, then you will see an alert in the
-        // speaker notes window
-        minimumTimePerSlide: $minimumTimePerSlide$,
-$endif$
-$if(mouseWheel)$
+
         // Enable slide navigation via mouse wheel
         mouseWheel: $mouseWheel$,
-$endif$
-$if(rollingLinks)$
-        // Apply a 3D roll to links on hover
-        rollingLinks: $rollingLinks$,
-$endif$
-$if(hideInactiveCursor)$
+
+        // The display mode that will be used to show slides
+        display: '$display$',
+
         // Hide cursor if inactive
         hideInactiveCursor: $hideInactiveCursor$,
-$endif$
-$if(hideCursorTime)$
+
         // Time before the cursor is hidden (in ms)
         hideCursorTime: $hideCursorTime$,
-$endif$
-$if(hideAddressBar)$
-        // Hides the address bar on mobile devices
-        hideAddressBar: $hideAddressBar$,
-$endif$
-$if(previewLinks)$
+
         // Opens links in an iframe preview overlay
         previewLinks: $previewLinks$,
-$endif$
-$if(transition)$
-        // Transition style
-        transition: '$transition$', // none/fade/slide/convex/concave/zoom
-$endif$
-$if(transitionSpeed)$
-        // Transition speed
-        transitionSpeed: '$transitionSpeed$', // default/fast/slow
-$endif$
-$if(backgroundTransition)$
+
+        // Transition style (none/fade/slide/convex/concave/zoom)
+        transition: '$transition$',
+
+        // Transition speed (default/fast/slow)
+        transitionSpeed: '$transitionSpeed$',
+
         // Transition style for full page slide backgrounds
-        backgroundTransition: '$backgroundTransition$', // none/fade/slide/convex/concave/zoom
-$endif$
-$if(viewDistance)$
+        // (none/fade/slide/convex/concave/zoom)
+        backgroundTransition: '$backgroundTransition$',
+
         // Number of slides away from the current that are visible
         viewDistance: $viewDistance$,
-$endif$
-$if(mobileViewDistance)$
+
         // Number of slides away from the current that are visible on mobile
         // devices. It is advisable to set this to a lower number than
         // viewDistance in order to save resources.
         mobileViewDistance: $mobileViewDistance$,
-$endif$
 $if(parallaxBackgroundImage)$
+
         // Parallax background image
         parallaxBackgroundImage: '$parallaxBackgroundImage$', // e.g. "'https://s3.amazonaws.com/hakim-static/reveal-js/reveal-parallax-1.jpg'"
 $else$
 $if(background-image)$
+
        // Parallax background image
        parallaxBackgroundImage: '$background-image$', // e.g. "'https://s3.amazonaws.com/hakim-static/reveal-js/reveal-parallax-1.jpg'"
 $endif$
 $endif$
 $if(parallaxBackgroundSize)$
+
         // Parallax background size
         parallaxBackgroundSize: '$parallaxBackgroundSize$', // CSS syntax, e.g. "2100px 900px"
 $endif$
 $if(parallaxBackgroundHorizontal)$
+
         // Amount to move parallax background (horizontal and vertical) on slide change
         // Number, e.g. 100
         parallaxBackgroundHorizontal: $parallaxBackgroundHorizontal$,
 $endif$
 $if(parallaxBackgroundVertical)$
+
         parallaxBackgroundVertical: $parallaxBackgroundVertical$,
 $endif$
 $if(width)$
+
         // The "normal" size of the presentation, aspect ratio will be preserved
         // when the presentation is scaled to fit different resolutions. Can be
         // specified using percentage units.
         width: $width$,
 $endif$
 $if(height)$
+
         height: $height$,
 $endif$
 $if(margin)$
+
         // Factor of the display size that should remain empty around the content
         margin: $margin$,
 $endif$
 $if(minScale)$
+
         // Bounds for smallest/largest possible scale to apply to content
         minScale: $minScale$,
 $endif$
 $if(maxScale)$
+
         maxScale: $maxScale$,
 $endif$
-$if(zoomKey)$
-        // Modifier key used to click-zoom to part of the slide
-        zoomKey: '$zoomKey$',
-$endif$
-$if(display)$
-        // The display mode that will be used to show slides
-        display: $display$,
-$endif$
 $if(mathjax)$
+
         math: {
           mathjax: '$mathjaxurl$',
           config: 'TeX-AMS_HTML-full',


### PR DESCRIPTION
Since version [4.2.0](https://github.com/hakimel/reveal.js/releases/tag/4.2.0) reveal.js supports [line number offset](https://revealjs.com/code/#line-number-offset-4.2.0) for presenting code. This pull request makes it available for the `revealjs_codeblock.lua` filter via Pandoc's `startFrom` [fenced code block attribute](https://pandoc.org/MANUAL.html#extension-fenced_code_attributes).

This was requested here: #201 