### PR TITLE
Add commonmark-code-blocks filter for producing CommonMark-suggested HTML for fenced code blocks

### DIFF
--- a/commonmark-code-blocks/Makefile
+++ b/commonmark-code-blocks/Makefile
@@ -1,0 +1,11 @@
+DIFF ?= diff --ignore-all-space --ignore-blank-lines -u
+PANDOC ?= pandoc
+
+.PHONY: test
+test:
+	@$(PANDOC) --lua-filter=commonmark-code-blocks.lua -f commonmark -t html sample.md | \
+		$(DIFF) expected.html -
+
+.PHONY: all
+all: test
+

--- a/commonmark-code-blocks/README.md
+++ b/commonmark-code-blocks/README.md
@@ -1,0 +1,23 @@
+# commonmark-code-blocks 
+
+This filter produces code blocks with language CSS class format
+suggested by the CommonMark specification ("language-$lang").
+
+The CommonMark spec suggests that converting ````somelang` to HTML
+should produce `<code class="language-somelang">`,
+as described in [example 141](https://spec.commonmark.org/0.30/#example-141).
+
+That's what most CommonMark implementations do.
+Pandoc, however, outputs `<code class="somelang">` instead.
+
+That can be a problem for syntax highlighters that expect
+`language-*` classes and use them to determine the language.
+ 
+This filter takes over the code block rendering process
+to produce CommonMark-style output.
+
+## Usage
+
+This filter does not require any setup or external tools.
+Just run pandoc with `--lua-filter=commonmark-code-blocks.lua`.
+

--- a/commonmark-code-blocks/commonmark-code-blocks.lua
+++ b/commonmark-code-blocks/commonmark-code-blocks.lua
@@ -1,0 +1,59 @@
+--[[
+
+commonmark-code-blocks -- produces code blocks with language CSS class format
+suggested by the CommonMark specification ("language-$lang").
+
+MIT License
+
+Copyright (c) 2021 Daniil Baturin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+]]
+
+--[[
+
+The CommonMark spec suggests that 
+"```somelang" should produce <code class="language-somelang">
+
+That's what most CommonMark implementations do.
+
+Pandoc, however, outputs <code class="somelang">
+
+That can be a problem for syntax highlighters that expect
+"language-*" classes and use them to determine the language.
+ 
+This filter takes over the code block rendering process
+to produce CommonMark-style output.
+
+]]
+
+function CodeBlock(block)
+  if FORMAT:match 'html' then
+    local lang_attr = ""
+    if (#block.classes > 0) then
+      lang_attr = string.format("class=\"language-%s\"", block.classes[1])
+    else
+      -- Ignore code blocks where language is not specified
+    end
+
+    local code = block.text:gsub("&", "&amp;"):gsub("<", "&lt;"):gsub(">", "&gt;")
+
+    local html = string.format('<pre><code %s>%s</code></pre>', lang_attr, code)
+    return pandoc.RawBlock('html', html)
+  end
+end
+

--- a/commonmark-code-blocks/expected.html
+++ b/commonmark-code-blocks/expected.html
@@ -1,0 +1,2 @@
+<pre><code class="language-basic">10 PRINT "HELLO WORLD"</code></pre>
+

--- a/commonmark-code-blocks/sample.md
+++ b/commonmark-code-blocks/sample.md
@@ -1,0 +1,3 @@
+```basic
+10 PRINT "HELLO WORLD"
+```


### PR DESCRIPTION
Pandoc's implementation of CommonMark code block rendering differs from that suggested by the [spec](https://spec.commonmark.org/0.30/#example-141) and used by most other Markdown convertors.

The suggested behavior is to output `<code class="language-$lang">`, while Pandoc omits the `language-` prefix, which may cause problems for syntax highlighters that rely on that spec-suggested behavior.

I made a simple filter to bring the code block rendering in line with the spec and other implementations.

It's used in one of my project's website build process for example, where pandoc is used as a [Markdown to HTML convertor](https://github.com/PataphysicalSociety/soupault.app/blob/master/soupault.toml#L23-L24), but syntax highlighting is [delegated to an external tool](https://github.com/PataphysicalSociety/soupault.app/blob/master/soupault.toml#L176-L181), and `*[class^="language-"]` CSS selector is used to find code elements with language specified. 