### PR TITLE
support for mermaidjs [enhancement] v2

### DIFF
--- a/.tools/Dockerfile
+++ b/.tools/Dockerfile
@@ -15,13 +15,49 @@ RUN apt-get -q --no-allow-insecure-repositories update \
        aspell-en \
        aspell-fr \
        asymptote \
+       ca-certificates \
+       chromium-browser \
        default-jre \
        dvisvgm \
+       fonts-liberation \
        graphviz \
        imagemagick \
        inkscape \
+       libappindicator3-1 \
+       libasound2 \
+       libatk-bridge2.0-0 \
+       libatk1.0-0 \
+       libc6 \
+       libcairo2 \
+       libcups2 \
+       libdbus-1-3 \
+       libexpat1 \
+       libfontconfig1 \
+       libgbm1 \
+       libgcc1 \
+       libglib2.0-0 \
+       libgtk-3-0 \
+       libnspr4 \
+       libnss3 \
+       libpango-1.0-0 \
+       libpangocairo-1.0-0 \
+       libstdc++6 \
+       libx11-6 \
+       libx11-xcb1 \
+       libxcb1 \
+       libxcomposite1 \
+       libxcursor1 \
+       libxdamage1 \
+       libxext6 \
+       libxfixes3 \
+       libxi6 \
+       libxrandr2 \
+       libxrender1 \
+       libxss1 \
+       libxtst6 \
        lilypond \
        lmodern \
+       lsb-release \
        luarocks \
        make \
        nodejs \
@@ -38,14 +74,15 @@ RUN apt-get -q --no-allow-insecure-repositories update \
        texlive-pictures \
        texlive-plain-generic \
        texlive-xetex \
-       wget
+       wget \
+       xdg-utils
 
 ARG plantuml_jar=plantuml.1.2018.9.jar
 RUN wget https://sourceforge.net/projects/plantuml/files/${plantuml_jar} \
       --quiet --output-document=/root/${plantuml_jar}
 ENV PLANTUML=/root/$plantuml_jar
 
-RUN npm install --global mathjax-node-cli
+RUN npm install --global mathjax-node-cli @mermaid-js/mermaid-cli --unsafe-perm=true
 
 ENV DIFF="diff -u"
 ENV LC_ALL="C.UTF-8"

--- a/.tools/Dockerfile
+++ b/.tools/Dockerfile
@@ -82,7 +82,13 @@ RUN wget https://sourceforge.net/projects/plantuml/files/${plantuml_jar} \
       --quiet --output-document=/root/${plantuml_jar}
 ENV PLANTUML=/root/$plantuml_jar
 
-RUN npm install --global mathjax-node-cli @mermaid-js/mermaid-cli --unsafe-perm=true
+RUN npm install --location=global mathjax-node-cli @mermaid-js/mermaid-cli
+
+# mermaid-cli uses puppeteer to control headless chromium.
+# the "simple" way to launch it inside a container is to add the `--no-sandbox`
+# parameter to puppeteer, through the `-p` mmdc option.
+RUN echo '{"args": ["--no-sandbox"]}' > /root/puppeteer-config.json
+ENV MERMAID_OPTIONS="-p /root/puppeteer-config.json"
 
 ENV DIFF="diff -u"
 ENV LC_ALL="C.UTF-8"

--- a/diagram-generator/README.md
+++ b/diagram-generator/README.md
@@ -219,6 +219,93 @@ key `activatePythonPath` to `c:\ProgramData\Anaconda3\Scripts\activate.bat`.
 
 Pandoc will activate this Python environment and starts Python with your code.
 
+## Asymptote
+[Asymptote](https://asymptote.sourceforge.io/) is a graphics
+language inspired by Metapost. To use Asymptote, you will need to
+install the software itself, a TeX distribution such as
+[TeX Live](https://www.tug.org/texlive/), and
+[dvisvgm](https://dvisvgm.de/), which may be included in the TeX
+distribution.
+
+If png output is required (such as for the `docx`, `pptx` and `rtf`
+output formats) Inkscape must be installed. See the Ti*k*Z section
+for details.
+
+Ensure that the Asymptote `asy` binary is in the path, or point
+the environment variable `ASYMPTOTE` or the metadata variable
+`asymptotePath` to the full path name. Asymptote calls the various
+TeX utilities and dvipdfm, so you will need to configure Asymptote
+so that it finds them.
+
+~~~~~~~~~~~~~~~~
+```{.asymptote caption="This is an image, created by **Asymptote**."}
+size(5cm);
+include graph;
+
+pair circumcenter(pair A, pair B, pair C)
+{
+  pair P, Q, R, S;
+  P = (A+B)/2;
+  Q = (B+C)/2;
+  R = rotate(90, P) * A;
+  S = rotate(90, Q) * B;
+  return extension(P, R, Q, S);
+}
+
+pair incenter(pair A, pair B, pair C)
+{
+  real a = abs(angle(C-A)-angle(B-A)),
+       b = abs(angle(C-B)-angle(A-B)),
+       c = abs(angle(A-C)-angle(B-C));
+  return (sin(a)*A + sin(b)*B + sin(c)*C) / (sin(a)+sin(b)+sin(c));
+}
+
+real dist_A_BC(pair A, pair B, pair C)
+{
+  real det = cross(B-A, C-A);
+  return abs(det/abs(B-C));
+}
+
+pair A = (0, 0), B = (5, 0), C = (3.5, 4),
+     O = circumcenter(A, B, C),
+     I = incenter(A, B, C);
+dot(A); dot(B); dot(C); dot(O, blue); dot(I, magenta);
+draw(A--B--C--cycle, linewidth(2));
+draw(Circle(O, abs(A-O)), blue+linewidth(1.5));
+draw(Circle(I, dist_A_BC(I, A, B)), magenta+linewidth(1.5));
+label("$A$", A, SW);
+label("$B$", B, SE);
+label("$C$", C, NE);
+label("$O$", O, W);
+label("$I$", I, E);
+```
+~~~~~~~~~~~~~~~~
+
+### Mermaid
+To use Mermaid, you must install mermaid-cli itself. See the
+[mermaid-cli website](https://github.com/mermaid-js/mermaid-cli) for more details.
+
+This filter assumes that the `mmdc` command is located in the path
+and therefore can be used from any location. Alternatively, you can
+set the environment variable `MERMAID` or use the pandoc's meta variable
+`mermaid_path`.
+
+Example usage from [the Mermaid page](https://github.com/mermaid-js/mermaid):
+
+~~~~~~~~~~~~~~~~
+```{.mermaid caption="This is a sequence diagram, created by **Mermaid**."}
+sequenceDiagram
+Alice->>John: Hello John, how are you?
+loop Healthcheck
+    John->>John: Fight against hypochondria
+end
+Note right of John: Rational thoughts!
+John-->>Alice: Great!
+John->>Bob: How about you?
+Bob-->>John: Jolly good!
+```
+~~~~~~~~~~~~~~~~
+
 ## How to run pandoc
 This section will show, how to call Pandoc in order to use this filter with
 meta keys. The following command assume, that the filters are stored in the
@@ -240,13 +327,17 @@ All available environment variables:
 - `JAVA_HOME` e.g. `c:\Program Files\Java\jre1.8.0_201`; Default: n/a
 - `DOT` e.g. `c:\ProgramData\chocolatey\bin\dot.exe`; Default: `dot`
 - `PDFLATEX` e.g. `c:\Program Files\MiKTeX 2.9\miktex\bin\x64\pdflatex.exe`; Default: `pdflatex`
+- `ASYMPTOTE` e.g. `c:\Program Files\Asymptote\asy`; Default: `asy`
+- `MERMAID` e.g. `c:\Program Files\nodejs\mmdc`; Default: `mmdc`
 
 All available meta keys:
 
-- `plantumlPath`
-- `inkscapePath`
-- `pythonPath`
-- `activatePythonPath`
-- `javaPath`
-- `dotPath`
-- `pdflatexPath`
+- `plantuml_path`
+- `inkscape_path`
+- `python_path`
+- `activate_python_path`
+- `java_path`
+- `dot_path`
+- `pdflatex_path`
+- `asymptote_path`
+- `mermaid_path`

--- a/diagram-generator/diagram-generator.lua
+++ b/diagram-generator/diagram-generator.lua
@@ -64,7 +64,7 @@ local pdflatex_path = os.getenv("PDFLATEX") or "pdflatex"
 local asymptote_path = os.getenv ("ASYMPTOTE") or "asy"
 
 -- The mermaid-cli path. In order to define an mermaid-cli version per pandoc
--- document, use the meta data to define the key "inkscape_path".
+-- document, use the meta data to define the key "mermaid_path".
 local mermaid_path = os.getenv("MERMAID") or "mmdc"
 
 -- The default format is SVG i.e. vector graphics:

--- a/diagram-generator/diagram-generator.lua
+++ b/diagram-generator/diagram-generator.lua
@@ -67,6 +67,9 @@ local asymptote_path = os.getenv ("ASYMPTOTE") or "asy"
 -- document, use the meta data to define the key "mermaid_path".
 local mermaid_path = os.getenv("MERMAID") or "mmdc"
 
+-- mermaid-cli additional options.
+local mermaid_options = os.getenv("MERMAID_OPTIONS") or ""
+
 -- The default format is SVG i.e. vector graphics:
 local filetype = "svg"
 local mimetype = "image/svg+xml"
@@ -116,6 +119,9 @@ function Meta(meta)
   )
   mermaid_path = stringify(
     meta.mermaid_path or meta.mermaidPath or mermaid_path
+  ) 
+  mermaid_options = stringify(
+    meta.mermaid_options or meta.mermaidOptions or mermaid_options
   ) 
 end
 
@@ -337,7 +343,13 @@ local function mermaid(code, filetype)
           f:close()
 
           local outfile = "pandoc_diagram." .. filetype
-          pandoc.pipe(mermaid_path, {"-o", outfile, "-i", mmd_file}, "")
+          local mmdc_parameters = {"-o", outfile, "-i", mmd_file}
+          if not(mermaid_options == "") then
+            for match in mermaid_options:gmatch("%S+") do
+              table.insert(mmdc_parameters, match)
+            end
+          end
+          pandoc.pipe(mermaid_path, mmdc_parameters, "")
 
           -- Try to open the written image:
           local r = io.open(outfile, 'rb')

--- a/diagram-generator/diagram-generator.lua
+++ b/diagram-generator/diagram-generator.lua
@@ -9,6 +9,7 @@ Copyright: © 2018-2021 John MacFarlane <jgm@berkeley.edu>,
              2018 Florian Schätzig <florian@schaetzig.de>,
              2019 Thorsten Sommer <contact@sommer-engineering.com>,
              2019-2021 Albert Krewinkel <albert+pandoc@zeitkraut.de>
+             2021 Moritz Mähr <moritz.maehr@gmail.com>
 License:   MIT – see LICENSE file for details
 ]]
 -- Module pandoc.system is required and was added in version 2.7.3
@@ -62,6 +63,10 @@ local pdflatex_path = os.getenv("PDFLATEX") or "pdflatex"
 -- "asymptote_path".
 local asymptote_path = os.getenv ("ASYMPTOTE") or "asy"
 
+-- The mermaid-cli path. In order to define an mermaid-cli version per pandoc
+-- document, use the meta data to define the key "inkscape_path".
+local mermaid_path = os.getenv("MERMAID") or "mmdc"
+
 -- The default format is SVG i.e. vector graphics:
 local filetype = "svg"
 local mimetype = "image/svg+xml"
@@ -109,6 +114,9 @@ function Meta(meta)
   asymptote_path = stringify(
      meta.asymptote_path or meta.asymptotePath or asymptote_path
   )
+  mermaid_path = stringify(
+    meta.mermaid_path or meta.mermaidPath or mermaid_path
+  ) 
 end
 
 -- Call plantuml.jar with some parameters (cf. PlantUML help):
@@ -310,6 +318,49 @@ local function asymptote(code, filetype)
   end)
 end
 
+-- Call mermaid-cli with some parameters (cf. mermaid-cli help):
+local function mermaid(code, filetype)
+  local convert
+  if filetype ~= 'svg' and filetype ~= 'pdf' and filetype ~= 'png' then
+    error(string.format("Conversion to %s not implemented", filetype))
+  end
+  return with_temporary_directory(
+    "mmdc",
+    function(tmpdir)
+      return with_working_directory(
+        tmpdir,
+        function ()
+          -- Try to write code to mmd file:
+          local mmd_file = "pandoc_diagram.mmd"
+          local f = io.open(mmd_file, 'w')
+          f:write(code)
+          f:close()
+
+          local outfile = "pandoc_diagram." .. filetype
+          pandoc.pipe(mermaid_path, {"-o", outfile, "-i", mmd_file}, "")
+
+          -- Try to open the written image:
+          local r = io.open(outfile, 'rb')
+          local img_data = nil
+
+          -- When the image exist, read it:
+          if r then
+            img_data = r:read("*all")
+            r:close()
+          else
+            io.stderr:write(string.format("File '%s' could not be opened", outfile))
+            error 'Could not create image from mermaid code.'
+          end
+
+          -- Delete the tmp files:
+          os.remove(mmd_file)
+          os.remove(outfile)
+
+          return img_data
+      end)
+  end)
+end
+
 -- Executes each document's code block to find matching code blocks:
 function CodeBlock(block)
   -- Using a table with all known generators i.e. converters:
@@ -319,6 +370,7 @@ function CodeBlock(block)
     tikz = tikz2image,
     py2image = py2image,
     asymptote = asymptote,
+    mermaid = mermaid,
   }
 
   -- Check if a converter exists for this block. If not, return the block

--- a/diagram-generator/sample.md
+++ b/diagram-generator/sample.md
@@ -271,6 +271,29 @@ label("$O$", O, W);
 label("$I$", I, E);
 ```
 
+### Mermaid
+To use Mermaid, you must install mermaid-cli itself. See the
+[mermaid-cli website](https://github.com/mermaid-js/mermaid-cli) for more details.
+
+This filter assumes that the `mmdc` command is located in the path
+and therefore can be used from any location. Alternatively, you can
+set the environment variable `MERMAID` or use the pandoc's meta variable
+`mermaid_path`.
+
+Example usage from [the Mermaid page](https://github.com/mermaid-js/mermaid):
+
+```{.mermaid caption="This is a sequence diagram, created by **Mermaid**."}
+sequenceDiagram
+Alice->>John: Hello John, how are you?
+loop Healthcheck
+    John->>John: Fight against hypochondria
+end
+Note right of John: Rational thoughts!
+John-->>Alice: Great!
+John->>Bob: How about you?
+Bob-->>John: Jolly good!
+```
+
 ## How to run pandoc
 This section will show, how to call Pandoc in order to use this filter with
 meta keys. The following command assume, that the filters are stored in the
@@ -293,6 +316,7 @@ All available environment variables:
 - `DOT` e.g. `c:\ProgramData\chocolatey\bin\dot.exe`; Default: `dot`
 - `PDFLATEX` e.g. `c:\Program Files\MiKTeX 2.9\miktex\bin\x64\pdflatex.exe`; Default: `pdflatex`
 - `ASYMPTOTE` e.g. `c:\Program Files\Asymptote\asy`; Default: `asy`
+- `MERMAID` e.g. `c:\Program Files\nodejs\mmdc`; Default: `mmdc`
 
 All available meta keys:
 
@@ -304,3 +328,4 @@ All available meta keys:
 - `dot_path`
 - `pdflatex_path`
 - `asymptote_path`
+- `mermaid_path`


### PR DESCRIPTION
Mermaid

EDIT: this PR is based on #181 and adds a couple of fixes to be able to use `mermaid-cli` inside a container (and fix the docker tests).

To use Mermaid, you must install `mermaid-cli` itself. See the
[mermaid-cli website](https://github.com/mermaid-js/mermaid-cli) for more details.

This filter assumes that the `mmdc` command is located in the path
and therefore can be used from any location. Alternatively, you can
set the environment variable `MERMAID` or use the pandoc's meta variable
`mermaid_path`.

Additionally, if you need to add additional parameters to the `mermaid-cli` command, you can use the `MERMAID_OPTIONS` environment variable.

Example usage from [the Mermaid page](https://github.com/mermaid-js/mermaid):

```
sequenceDiagram
Alice->>John: Hello John, how are you?
loop Healthcheck
    John->>John: Fight against hypochondria
end
Note right of John: Rational thoughts!
John-->>Alice: Great!
John->>Bob: How about you?
Bob-->>John: Jolly good!
```