### PR TITLE
Fixing issue related to pandoc-crossref compatibility

### DIFF
--- a/minted/minted.lua
+++ b/minted/minted.lua
@@ -404,12 +404,21 @@ function CodeBlock(block)
   if FORMAT == "beamer" or FORMAT == "latex" then
     local language   = minted_language(block, MintedBlock)
     local attributes = minted_attributes(block, MintedBlock)
+
+    if (block.identifier == "") then
+        label = ""
+    else
+        label = string.format("\\label{%s}", block.identifier)
+    end
+
     local raw_minted = string.format(
-      "\\begin{minted}[%s]{%s}\n%s\n\\end{minted}",
+      "%s\n\\begin{minted}[%s]{%s}\n%s\n\\end{minted}",
+      label,
       attributes,
       language,
       block.text
     )
+
     -- NOTE: prior to pandoc commit 24a0d61, `beamer` cannot be used as the
     -- RawBlock format.  Using `latex` should not cause any problems.
     return pandoc.RawBlock("latex", raw_minted)


### PR DESCRIPTION
`minted.lua` unconditionally strips the code block identifier when processing with `pandoc-crossref`. This makes the current implementation of `minted.lua`  incompatible with `pandoc-crossref`. Please see [this thread ](https://github.com/lierdakil/pandoc-crossref/issues/379) for more details.

This change allows documents filtered by `pandoc-crossref` and *then* by `minted.lua` to preserve references. This combines the best of both worlds.

I was not able to run the tests to check if this is a breaking change, because of [this issue](https://askubuntu.com/questions/1458474/unable-to-use-apt-in-wsl-ubuntu-due-to-security-issues) in my WSL install. If someone can show me how to run the tests for `minted.lua` on a Windows machine and there are breaking changes I'd be glad to work through them or add new tests if necessary.

@tarleb 