### PR TITLE
Added support for mermaid (again)

### DIFF
--- a/diagram-generator/sample.md
+++ b/diagram-generator/sample.md
@@ -270,6 +270,25 @@ label("$O$", O, W);
 label("$I$", I, E);
 ```
 
+## Mermaid
+[Mermaid](https://mermaid.js.org/#/) is a diagramming and charting tool.
+[mmdc](https://github.com/mermaid-js/mermaid-cli) is a cli to mermaid.
+Your distribution may have a package called `mermaid-cli` or `mmdc`.
+
+```{.mermaid caption="Sample git graph, created by **mermaid**."}
+gitGraph
+    commit
+    commit
+    branch develop
+    checkout develop
+    commit
+    commit
+    checkout main
+    merge develop
+    commit
+    commit
+```
+
 ## How to run pandoc
 This section will show, how to call Pandoc in order to use this filter with
 meta keys. The following command assume, that the filters are stored in the
@@ -292,6 +311,7 @@ All available environment variables:
 - `DOT` e.g. `c:\ProgramData\chocolatey\bin\dot.exe`; Default: `dot`
 - `PDFLATEX` e.g. `c:\Program Files\MiKTeX 2.9\miktex\bin\x64\pdflatex.exe`; Default: `pdflatex`
 - `ASYMPTOTE` e.g. `c:\Program Files\Asymptote\asy`; Default: `asy`
+- `MERMAID` e.g. `??`; Default: `mmdc`
 
 All available meta keys:
 
@@ -303,3 +323,4 @@ All available meta keys:
 - `dot_path`
 - `pdflatex_path`
 - `asymptote_path`
+- `mermaid_path`


### PR DESCRIPTION
I wrote this before looking at all these PR in lua-filters repo...
My code is a little bit different from this one :   #181  so I decided to make a PR if it can help.
When generating pdf output, pdf should be stretched to the diagram (option -f) or you will get a whole white page with a small diagram inside.
It seems that something is wrong with svg output https://github.com/mermaid-js/mermaid-cli/issues/112
It didn't work correctly with my 10.0.0 mmdc version. I decided to render to pdf and convert pdf to svg (you must have svg2pdf). I think this is a temporary situation.

I read a few lua filters that make a job similar to diagram-generator. Some of them have a more precise way of choosing the output format based on the type of diagram and the pandoc output format.  You can say things like : if the output format is latex or pdf, and the diagram is mermaid, then preferred output file type is pdf or else svg.

Fill free to delete my PR if it does not help.